### PR TITLE
Fix when FQDN is not resolved by socket.getfqdn(ip)

### DIFF
--- a/rrmngmnt/host.py
+++ b/rrmngmnt/host.py
@@ -59,9 +59,9 @@ class Host(Resource):
         :type service_provider: class which implement SystemService interface
         """
         super(Host, self).__init__()
-        self.h_fqdn = None
+        self._fqdn = None
         if not netaddr.valid_ipv4(ip):
-            self.h_fqdn = ip
+            self._fqdn = ip
             ip = fqdn2ip(ip)
         self.ip = ip
         self.users = list()
@@ -104,7 +104,7 @@ class Host(Resource):
 
     @property
     def fqdn(self):
-        return socket.getfqdn(self.ip) if not self.h_fqdn else self.h_fqdn
+        return socket.getfqdn(self.ip) if not self._fqdn else self._fqdn
 
     def add_power_manager(self, pm_type, **init_params):
         """

--- a/rrmngmnt/host.py
+++ b/rrmngmnt/host.py
@@ -59,9 +59,9 @@ class Host(Resource):
         :type service_provider: class which implement SystemService interface
         """
         super(Host, self).__init__()
-        self.host_fqdn = None
+        self.h_fqdn = None
         if not netaddr.valid_ipv4(ip):
-            self.host_fqdn = ip
+            self.h_fqdn = ip
             ip = fqdn2ip(ip)
         self.ip = ip
         self.users = list()
@@ -104,7 +104,7 @@ class Host(Resource):
 
     @property
     def fqdn(self):
-        return socket.getfqdn(self.ip) if not self.host_fqdn else self.host_fqdn
+        return socket.getfqdn(self.ip) if not self.h_fqdn else self.h_fqdn
 
     def add_power_manager(self, pm_type, **init_params):
         """

--- a/rrmngmnt/host.py
+++ b/rrmngmnt/host.py
@@ -59,7 +59,9 @@ class Host(Resource):
         :type service_provider: class which implement SystemService interface
         """
         super(Host, self).__init__()
+        self.host_fqdn = None
         if not netaddr.valid_ipv4(ip):
+            self.host_fqdn = ip
             ip = fqdn2ip(ip)
         self.ip = ip
         self.users = list()
@@ -102,7 +104,7 @@ class Host(Resource):
 
     @property
     def fqdn(self):
-        return socket.getfqdn(self.ip)
+        return socket.getfqdn(self.ip) if not self.host_fqdn else self.host_fqdn
 
     def add_power_manager(self, pm_type, **init_params):
         """

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -30,3 +30,16 @@ class TestExecutorUser(object):
         h.executor_user = user
         e = h.executor()
         e.user.name == 'lukas'
+
+
+class TestHostFqdnIp(object):
+
+    def test_host_ip(self):
+        h = Host('127.0.0.1')
+        assert h.ip == '127.0.0.1'
+        assert h.fqdn == 'localhost.localdomain'
+
+    def test_host_fqdn(self):
+        h = Host('localhost')
+        assert h.ip == '127.0.0.1'
+        assert h.fqdn == 'localhost.localdomain'

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -37,9 +37,9 @@ class TestHostFqdnIp(object):
     def test_host_ip(self):
         h = Host('127.0.0.1')
         assert h.ip == '127.0.0.1'
-        assert h.fqdn == 'localhost.localdomain'
+        assert h.fqdn == 'localhost'
 
     def test_host_fqdn(self):
         h = Host('localhost')
         assert h.ip == '127.0.0.1'
-        assert h.fqdn == 'localhost.localdomain'
+        assert h.fqdn == 'localhost'


### PR DESCRIPTION
In some cases socket.getfqdn(ip) return IP and not the host FQDN so if Host
was created with FQDN we will use it as FQDN