### PR TITLE
Modify FileSystem.touch method

### DIFF
--- a/rrmngmnt/filesystem.py
+++ b/rrmngmnt/filesystem.py
@@ -1,6 +1,7 @@
 import os
 
 import six
+import warnings
 
 from rrmngmnt import errors
 from rrmngmnt.service import Service
@@ -52,7 +53,25 @@ class FileSystem(Service):
             ['ls', '-A1', path]
         )[1].split()
 
-    def touch(self, file_name, path):
+    def touch(self, *args):
+        """
+        Creates files on host
+
+        __author__ = "vkondula"
+        :param args: Paths of files to create
+        :type args: list of str
+        :returns: True when file creation succeeds, False otherwise
+        :rtype: bool
+        """
+        if len(args) == 2 and self.isdir(args[1]):
+            warnings.warn(
+                "This usecase is deprecated and will be removed. "
+                "Use list of fullpaths instead"
+            )
+            return self._deprecated_touch(args[0], args[1])
+        return self.host.run_command(['touch'] + list(args))[0] == 0
+
+    def _deprecated_touch(self, file_name, path):
         """
         Creates a file on host
 
@@ -62,7 +81,6 @@ class FileSystem(Service):
         :param path: The path under which the file will be created
         :type path: str
         :returns: True when file creation succeeds, False otherwise
-        False otherwise
         :rtype: bool
         """
         full_path = os.path.join(path, file_name)

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -30,6 +30,9 @@ class TestFilesystem(object):
         '[ -f /tmp/nofile ]': (1, '', ''),
         '[ -d /tmp/dir ]': (0, '', ''),
         '[ -d /tmp/nodir ]': (1, '', ''),
+        '[ -d /path/to/file1 ]': (1, '', ''),
+        '[ -d /path/to ]': (0, '', ''),
+        '[ -d somefile ]': (1, '', ''),
         'rm -f /path/to/remove': (0, '', ''),
         'rm -f /dir/to/remove': (
             1, '', 'rm: cannot remove ‘.tox/’: Is a directory',
@@ -44,7 +47,8 @@ class TestFilesystem(object):
             1, '',
             'chmod: cannot access ‘/tmp/nofile’: No such file or directory',
         ),
-        'touch /path/to/file': (0, '', ''),
+        'touch /path/to/file /path/to/file1': (0, '', ''),
+        'touch /path/to/file2': (0, '', ''),
         'touch /path/to/nopermission': (1, '', ''),
         'ls -A1 /path/to/empty': (0, '\n', ''),
         'ls -A1 /path/to/two': (0, 'first\nsecond\n', ''),
@@ -113,10 +117,13 @@ class TestFilesystem(object):
         assert "No such file or directory" in str(ex_info.value)
 
     def test_touch_positive(self):
-        assert self.get_host().fs.touch('/path/to/file', '')
+        assert self.get_host().fs.touch('/path/to/file', '/path/to/file1')
 
     def test_touch_negative(self):
-        assert not self.get_host().fs.touch('/path/to/nopermission', '')
+        assert not self.get_host().fs.touch('/path/to/nopermission')
+
+    def test_backwards_comp_touch(self):
+        assert self.get_host().fs.touch('file2', '/path/to')
 
     def test_touch_wrong_params(self):
         with pytest.raises(Exception) as ex_info:


### PR DESCRIPTION
This method now expects same parameters as unix touch command
Backwards compatibility has been preserved with a deprecated warning
fixes: #48