### PR TITLE
Add host with ipv6

### DIFF
--- a/rrmngmnt/host.py
+++ b/rrmngmnt/host.py
@@ -61,9 +61,7 @@ class Host(Resource):
         :type service_provider: class which implement SystemService interface
         """
         super(Host, self).__init__()
-        self._fqdn = None
-        if not netaddr.valid_ipv4(ip):
-            self._fqdn = ip
+        if not netaddr.valid_ipv4(ip) and not netaddr.valid_ipv6(ip):
             ip = fqdn2ip(ip)
         self.ip = ip
         self.users = list()
@@ -107,7 +105,7 @@ class Host(Resource):
 
     @property
     def fqdn(self):
-        return socket.getfqdn(self.ip) if not self._fqdn else self._fqdn
+        return socket.getfqdn(self.ip)
 
     def add_power_manager(self, pm_type, **init_params):
         """

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -37,9 +37,9 @@ class TestHostFqdnIp(object):
     def test_host_ip(self):
         h = Host('127.0.0.1')
         assert h.ip == '127.0.0.1'
-        assert h.fqdn == 'localhost'
+        assert 'localhost' in h.fqdn
 
     def test_host_fqdn(self):
         h = Host('localhost')
         assert h.ip == '127.0.0.1'
-        assert h.fqdn == 'localhost'
+        assert 'localhost' in h.fqdn

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -48,6 +48,19 @@ class TestNetwork(object):
             ),
             '',
         ),
+        'ip -6 route': (
+            0,
+            '\n'.join(
+                [
+                    'unreachable ::/96 dev lo  metric 1024  error -101',
+                    'unreachable 2002:a9fe::/32 lo metric 1024  error -101',
+                    'unreachable 2002:ac10::/28 lo metric 1024  error -101',
+                    'fe80:52:0::3fe dev eth0  proto static  metric 100 ',
+                    'default via fe80::0:3fe dev eth0 proto static metric 100',
+                ]
+            ),
+            '',
+        ),
         'ip addr': (
             0,
             ''.join(
@@ -111,6 +124,36 @@ class TestNetwork(object):
                     '    inet 10.11.12.83/24 brd 10.11.12.255 scope global '
                     'enp5s0f0',
                     '           valid_lft forever preferred_lft forever',
+                ]
+            ),
+            ''
+        ),
+        'ip addr show eth0': (
+            0,
+            '\n'.join(
+                [
+                    '2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu ...',
+                    'link/ether 00:1a:4a:01:3f:1c brd ff:ff:ff:ff:ff:ff',
+                    'inet 10.11.12.84/22 brd 10.11.12.255 scope global',
+                    'valid_lft 20343sec preferred_lft 20343sec',
+                    'inet6 2620:52:0::fe01:3f1c/64 scope global dynamic',
+                    'valid_lft 2591620sec preferred_lft 604420sec',
+                    'inet6 fe80::4aff:fe01:3f1c/64 scope link ',
+                    'valid_lft forever preferred_lft forever',
+                ]
+            ),
+            ''
+        ),
+        'ip -6 addr show eth0': (
+            0,
+            '\n'.join(
+                [
+                    '2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu ...',
+                    'link/ether 00:1a:4a:01:3f:1c brd ff:ff:ff:ff:ff:ff',
+                    'inet6 2620:52:0::fe01:3f1c/64 scope global dynamic',
+                    'valid_lft 2591620sec preferred_lft 604420sec',
+                    'inet6 fe80::4aff:fe01:3f1c/64 scope link ',
+                    'valid_lft forever preferred_lft forever',
                 ]
             ),
             ''
@@ -200,6 +243,16 @@ class TestNetwork(object):
     def test_get_mac_address_by_ip(self):
         expected = "44:1e:a1:73:3c:98"
         assert get_host().network.get_mac_by_ip("10.11.12.83") == expected
+
+    def test_find_ip_by_int(self):
+        assert get_host().network.find_ip_by_int("eth0") == "10.11.12.84"
+
+    def test_find_ipv6_by_int(self):
+        expected = "2620:52:0::fe01:3f1c"
+        assert get_host().network.find_ipv6_by_int("eth0") == expected
+
+    def test_find_default_gwv6(self):
+        assert get_host().network.find_default_gwv6() == "fe80::0:3fe"
 
     def if_up(self):
         assert get_host().network.if_up("interface")


### PR DESCRIPTION
You can add host using ipv6
Always try to resolve FQDN. Before if you created host
 with domain name but not fully qualified it was stored
 as fqdn
Add ability to find default ipv6 for gateway.
Add ability to find ipv6 by interface
fixes: #56 
