### PR TITLE
power_manager: add reasonable timeout for SSH actions

### DIFF
--- a/rrmngmnt/power_manager.py
+++ b/rrmngmnt/power_manager.py
@@ -62,7 +62,9 @@ class SSHPowerManager(PowerManager):
         try:
             t_command = list(command)
             t_command += args
-            self.host.executor().run_cmd(t_command)
+            self.host.executor().run_cmd(
+                t_command, tcp_timeout=20, io_timeout=20
+            )
         except socket.timeout as e:
             self.logger.debug("Socket timeout: %s", e)
         except Exception as e:


### PR DESCRIPTION
Sometime the code can stuck, because of command like `poweroff -f`,
so we need to add reasonable timeout for TCP and IO.