### PR TITLE
ssh.py: Convert to unicode output which is not encoded with ascci

### DIFF
--- a/rrmngmnt/ssh.py
+++ b/rrmngmnt/ssh.py
@@ -185,8 +185,8 @@ class RemoteExecutor(Executor):
                 if self._err is not None:
                     self._err.close()
                 self.logger.debug("Results of command: %s", self.cmd)
-                self.logger.debug("  OUT: %s", self.out)
-                self.logger.debug("  ERR: %s", self.err)
+                self.logger.debug("  OUT: %s", unicode(self.out,'utf8'))
+                self.logger.debug("  ERR: %s", unicode(self.err, 'utf8'))
                 self.logger.debug("  RC: %s", self.rc)
 
         def run(self, input_, timeout=None, get_pty=False):


### PR DESCRIPTION
Here we get some output which is not encoded with ascii,
and we need to convert it to unicode.

In our tests pytest is capturing logs from this logger.
Then internally pytest is trying to join this captured logs and failed with the following:

```
INTERNALERROR>     return ''.join(content for (prefix, content) in self.get_sections('Captured stdout'))
INTERNALERROR> UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 35: ordinal not in range(128)
```

I am not sure if we would like this fix here, I also have one PR in the pytest side. pytest-dev/pytest#3172