### PR TITLE
Change send_icmp to use OS default ping size

### DIFF
--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -545,7 +545,7 @@ class Network(Service):
             return False
         return True
 
-    def send_icmp(self, dst, count="5", size="1500", extra_args=None):
+    def send_icmp(self, dst, count="5", size=None, extra_args=None):
         """
         Send ICMP to destination IP/FQDN
 
@@ -558,9 +558,9 @@ class Network(Service):
         Returns:
             bool: True/false
         """
-        cmd = ["ping", dst, "-c", count, "-s", size]
-        if size != "1500":
-            cmd.extend(["-M", "do"])
+        cmd = ["ping", dst, "-c", count]
+        if size is not None:
+            cmd.extend(["-s", str(size), "-M", "do"])
         if extra_args is not None:
             for ar in extra_args.split():
                 cmd.extend(ar.split())


### PR DESCRIPTION
Changed send_icmp function to use default host OS ping size
in case a size is not passed to the fuction