### PR TITLE
Fix PEP errors in network module

### DIFF
--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -190,8 +190,7 @@ class Network(Service):
             list of strings: List of interfaces
         """
         out = self._cmd(
-            "ls -la /sys/class/net | grep 'dummy_\|pci' | grep -o '["
-            "^/]*$'".split()
+            r"ls -la /sys/class/net | grep 'dummy_\|pci' | grep -o '[""^/]*$'".split()
         )
         out = out.strip().splitlines()
         out.sort(key=lambda x: 'dummy_' in x)
@@ -396,9 +395,9 @@ class Network(Service):
         bridges = []
         cmd = [
             'brctl', 'show', '|',
-            'sed', '-e', '/^bridge name/ d',  # remove header
+            'sed', '-e', r'/^bridge name/ d',  # remove header
             # deal with multiple interfaces
-            '-e', "'s/^\s\s*\(\S\S*\)$/CONT:\\1/I'"
+            '-e', r"'s/^\s\s*\(\S\S*\)$/CONT:\\1/I'"
         ]
         out = self._cmd(cmd).strip()
         if not out:

--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -190,7 +190,8 @@ class Network(Service):
             list of strings: List of interfaces
         """
         out = self._cmd(
-            r"ls -la /sys/class/net | grep 'dummy_\|pci' | grep -o '[""^/]*$'".split()
+            "ls -la /sys/class/net | grep 'dummy_\\|pci' | grep -o '["
+            "^/]*$'".split()
         )
         out = out.strip().splitlines()
         out.sort(key=lambda x: 'dummy_' in x)
@@ -397,7 +398,11 @@ class Network(Service):
             'brctl', 'show', '|',
             'sed', '-e', r'/^bridge name/ d',  # remove header
             # deal with multiple interfaces
+<<<<<<< HEAD
             '-e', r"'s/^\s\s*\(\S\S*\)$/CONT:\\1/I'"
+=======
+            '-e', "'s/^\\s\\s*\\(\\S\\S*\\)$/CONT:\\1/I'"
+>>>>>>> Fixed the following PEP errors by converting the string
         ]
         out = self._cmd(cmd).strip()
         if not out:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -166,7 +166,7 @@ class TestNetwork(object):
         ),
         'brctl addbr br1': (0, '', ''),
         'brctl addif br1 net1': (0, '', ''),
-        r'ls -la /sys/class/net | grep \'dummy_\|pci\' | grep -o \'[^/]*$\'': (
+        'ls -la /sys/class/net | grep \'dummy_\\|pci\' | grep -o \'[^/]*$\'': (
             0,
             '\n'.join(
                 [

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -166,7 +166,7 @@ class TestNetwork(object):
         ),
         'brctl addbr br1': (0, '', ''),
         'brctl addif br1 net1': (0, '', ''),
-        'ls -la /sys/class/net | grep \'dummy_\|pci\' | grep -o \'[^/]*$\'': (
+        r'ls -la /sys/class/net | grep \'dummy_\|pci\' | grep -o \'[^/]*$\'': (
             0,
             '\n'.join(
                 [


### PR DESCRIPTION
Fixed the following PEP errors by converting the string
literals to raw string literals:

rrmngmnt/network.py:193:34: W605 invalid escape sequence '\|'
rrmngmnt/network.py:397:14: W605 invalid escape sequence '\s'
rrmngmnt/network.py:397:16: W605 invalid escape sequence '\s'
rrmngmnt/network.py:398:16: W605 invalid escape sequence '\('
rrmngmnt/network.py:398:18: W605 invalid escape sequence '\S'
rrmngmnt/network.py:398:20: W605 invalid escape sequence '\S'
rrmngmnt/network.py:398:23: W605 invalid escape sequence '\)'
tests/test_network.py:32:24: W605 invalid escape sequence '\|'