### PR TITLE
Fix some PEP comments that travis found

### DIFF
--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -190,7 +190,7 @@ class Network(Service):
             list of strings: List of interfaces
         """
         out = self._cmd(
-            "ls -la /sys/class/net | grep 'dummy_\|pci' | grep -o '["
+            "ls -la /sys/class/net | grep 'dummy_\\|pci' | grep -o '["
             "^/]*$'".split()
         )
         out = out.strip().splitlines()
@@ -398,7 +398,7 @@ class Network(Service):
             'brctl', 'show', '|',
             'sed', '-e', '/^bridge name/ d',  # remove header
             # deal with multiple interfaces
-            '-e', "'s/^\s\s*\(\S\S*\)$/CONT:\\1/I'"
+            '-e', "'s/^\\s\\s*\\(\\S\\S*\\)$/CONT:\\1/I'"
         ]
         out = self._cmd(cmd).strip()
         if not out:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -166,7 +166,7 @@ class TestNetwork(object):
         ),
         'brctl addbr br1': (0, '', ''),
         'brctl addif br1 net1': (0, '', ''),
-        'ls -la /sys/class/net | grep \'dummy_\|pci\' | grep -o \'[^/]*$\'': (
+        'ls -la /sys/class/net | grep \'dummy_\\|pci\' | grep -o \'[^/]*$\'': (
             0,
             '\n'.join(
                 [


### PR DESCRIPTION
There was one error of type:
'W605 invalid escape sequence' that was repeating itself
in several places in the network and test_network modules