### PR TITLE
Change send_icmp to use OS default ping size

### DIFF
--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -545,7 +545,7 @@ class Network(Service):
             return False
         return True
 
-    def send_icmp(self, dst, count="5", size="1500", extra_args=None):
+    def send_icmp(self, dst, count="5", size=None, extra_args=None):
         """
         Send ICMP to destination IP/FQDN
 
@@ -558,10 +558,10 @@ class Network(Service):
         Returns:
             bool: True/false
         """
-        cmd = ["ping", dst, "-c", count, "-s", size]
-        if size != "1500":
-            cmd.extend(["-M", "do"])
-        if extra_args is not None:
+        cmd = ["ping", dst, "-c", count]
+        if size:
+            cmd.extend(["-s", size, "-M", "do"])
+        if extra_args:
             for ar in extra_args.split():
                 cmd.extend(ar.split())
         try:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -187,7 +187,8 @@ class TestNetwork(object):
         'ip link set down interface': True,
         "ethtool -i eth0": (0, "driver: e1000", ""),
         "cat /sys/class/net/eth0/speed": (0, "1000", ""),
-        "cat /sys/class/net/eth0/operstate": (0, "up", "")
+        "cat /sys/class/net/eth0/operstate": (0, "up", ""),
+        "ping 1.2.3.4 -c 5 -s 10 -M do": (0, "something", ""),
     }
     files = {
     }
@@ -264,6 +265,9 @@ class TestNetwork(object):
 
     def test_get_interface_status(self):
         assert get_host().network.get_interface_status("eth0") == "up"
+
+    def test_send_icmp(self):
+        assert get_host().network.send_icmp('1.2.3.4', size="10")
 
 
 class TestHostNameCtl(object):


### PR DESCRIPTION
Changed send_icmp function to use default host OS ping size
in case a size is not passed to the fuction