### PR TITLE
Add Database.psql_cmd to run special psql commands like \dt, \dv

### DIFF
--- a/rrmngmnt/db.py
+++ b/rrmngmnt/db.py
@@ -50,7 +50,7 @@ class Database(Service):
 
     def psql_cmd(self, command):
         """
-        Execute psql special command on host (e.g. \dt, \dv, ...)
+        Execute psql special command on host (e.g. \\dt, \\dv, ...)
 
         Args:
             command (str): special psql command

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -66,3 +66,8 @@ class TestDb(object):
         with pytest.raises(Exception) as ex_info:
             db.psql("SELECT * FROM table ERROR")
         assert "Syntax Error" in str(ex_info.value)
+
+    def test_psql_cmd(self):
+        db = self.get_db()
+        res = db.psql_cmd('\dt')
+        assert res

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -36,7 +36,18 @@ class TestDb(object):
         ),
         'export PGPASSWORD=db_pass; psql -d db_name -U db_user -h localhost '
         '-c \\\dt': (
-            0, "", ""
+            0,
+            (
+                "List of relations\n"
+                " Schema |         Name         | Type  | Owner\n"
+                "--------+----------------------+-------+---------\n"
+                " public | test_table           | table | postgres\n"
+            ),
+            ""
+        ),
+        'export PGPASSWORD=db_pass; psql -d db_name -U db_user -h localhost '
+        '-c \\\dv': (
+            0, "", "Did not find any relations."
         ),
     }
     files = {}
@@ -74,4 +85,6 @@ class TestDb(object):
     def test_psql_cmd(self):
         db = self.get_db()
         res = db.psql_cmd('\\\dt')
-        assert res
+        assert 'List of relations' in res
+        res = db.psql_cmd('\\\dv')
+        assert res == 'Did not find any relations.'

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -35,7 +35,7 @@ class TestDb(object):
             1, "", "Syntax Error"
         ),
         'export PGPASSWORD=db_pass; psql -d db_name -U db_user -h localhost '
-        '-c "\\\dt"': (
+        '-c \\\dt': (
             0, "", ""
         ),
     }

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -34,6 +34,10 @@ class TestDb(object):
         '-R __RECORD_SEPARATOR__ -t -A -c "SELECT * FROM table ERROR"': (
             1, "", "Syntax Error"
         ),
+        'export PGPASSWORD=db_pass; psql -d db_name -U db_user -h localhost '
+        '-c "\\\dt"': (
+            0, "", ""
+        ),
     }
     files = {}
 
@@ -69,5 +73,5 @@ class TestDb(object):
 
     def test_psql_cmd(self):
         db = self.get_db()
-        res = db.psql_cmd('\dt')
+        res = db.psql_cmd('\\\dt')
         assert res

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -49,6 +49,10 @@ class TestDb(object):
         '-c \\\\dv': (
             0, "", "Did not find any relations."
         ),
+        'export PGPASSWORD=db_pass; psql -d db_name -U db_user -h localhost '
+        '-c \\\\gg': (
+            1, "", "invalid command \\gg"
+        ),
     }
     files = {}
 
@@ -88,3 +92,9 @@ class TestDb(object):
         assert 'List of relations' in res
         res = db.psql_cmd('\\\\dv')
         assert res == 'Did not find any relations.'
+
+    def test_negative_cmd(self):
+        db = self.get_db()
+        with pytest.raises(Exception) as ex_info:
+            db.psql_cmd('\\\\gg')
+        assert 'invalid command' in str(ex_info.value)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -35,7 +35,7 @@ class TestDb(object):
             1, "", "Syntax Error"
         ),
         'export PGPASSWORD=db_pass; psql -d db_name -U db_user -h localhost '
-        '-c \\\dt': (
+        '-c \\\\dt': (
             0,
             (
                 "List of relations\n"
@@ -46,7 +46,7 @@ class TestDb(object):
             ""
         ),
         'export PGPASSWORD=db_pass; psql -d db_name -U db_user -h localhost '
-        '-c \\\dv': (
+        '-c \\\\dv': (
             0, "", "Did not find any relations."
         ),
     }
@@ -84,7 +84,7 @@ class TestDb(object):
 
     def test_psql_cmd(self):
         db = self.get_db()
-        res = db.psql_cmd('\\\dt')
+        res = db.psql_cmd('\\\\dt')
         assert 'List of relations' in res
-        res = db.psql_cmd('\\\dv')
+        res = db.psql_cmd('\\\\dv')
         assert res == 'Did not find any relations.'


### PR DESCRIPTION
Method added to not specially parse psql output for result rows. Result also can be returned in err (from PG10) when rc = 0.