### PR TITLE
Implement running Ansible playbook on Host

### DIFF
--- a/rrmngmnt/host.py
+++ b/rrmngmnt/host.py
@@ -62,8 +62,8 @@ class Host(Resource):
         Args:
             ip (str): IP address of machine or resolvable FQDN
             service_provider (Service): system service handler
-            playbook_logger (logging.Logger): You may provide alternative logger
-            only for Ansible-related events
+            playbook_logger (logging.Logger): You may provide alternative
+            logger only for Ansible-related events
         """
         super(Host, self).__init__()
         if not netaddr.valid_ipv4(ip) and not netaddr.valid_ipv6(ip):
@@ -234,7 +234,7 @@ class Host(Resource):
             ef.use_pkey = pkey
             return ef(self.ip, user)
         return self.executor_factory.build(self, user)
-    
+
     def playbook_executor(self):
         """
         Gives you executor allowing you Ansible playbook execution.
@@ -245,7 +245,7 @@ class Host(Resource):
         """
         return self.playbook_executor_factory.build(
             self,
-            self.executor_user, 
+            self.executor_user,
             executor_logger=self.playbook_logger
         )
 
@@ -277,9 +277,9 @@ class Host(Resource):
         return rc, out, err
 
     def run_playbook(
-        self, playbook_path_local, playbook_remote_dir="/root", extra_vars=None,
-        run_in_check_mode=False, vars_files=None, verbose_level=1, 
-        inventory=None, tcp_timeout=None, io_timeout=None
+        self, playbook_path_local, playbook_remote_dir="/root",
+        extra_vars=None, run_in_check_mode=False, vars_files=None,
+        verbose_level=1, inventory=None, tcp_timeout=None, io_timeout=None
     ):
         """
         Run Ansible playbook on host
@@ -291,15 +291,15 @@ class Host(Resource):
             extra_vars (dict): Dictionary of extra variables that are to be
             provided to playbook execution. They will be dumpled into JSON file
             and included using -e@ parameter
-            run_in_check_mode (bool): If True, playbook will not actually be 
+            run_in_check_mode (bool): If True, playbook will not actually be
             executed, but instead run with --check parameter
-            vars_files (list): List of additional variable files on your local 
+            vars_files (list): List of additional variable files on your local
             file system to be included using -e@ parameter. Variables specified
             in those files will override those specified in extra_vars param
-            verbose_level (int): How much should playbook be verbose. Possible 
+            verbose_level (int): How much should playbook be verbose. Possible
             values are 1 through 5
             inventory (str): Path to an inventory file on your local file
-            system. If none is provided, inventory including localhost will be 
+            system. If none is provided, inventory including localhost will be
             generated and used
             tcp_timeout (float): tcp timeout
             io_timeout (float): timeout for data operation (read/write)
@@ -310,12 +310,14 @@ class Host(Resource):
         files = []  # Files created on host by this function
 
         executor = self.playbook_executor()
-        
+
         # Upload playbook to the host
         playbook_path_remote = os.path.join(
             playbook_remote_dir, os.path.basename(playbook_path_local),
         )
-        self.fs.put(path_src=playbook_path_local, path_dst=playbook_path_remote)
+        self.fs.put(
+            path_src=playbook_path_local, path_dst=playbook_path_remote
+        )
         files.append(playbook_path_remote)
 
         # Dump user-provided extra vars to a file
@@ -327,7 +329,7 @@ class Host(Resource):
                 content=json.dumps(extra_vars), path=extra_vars_file,
             )
             files.append(extra_vars_file)
-        
+
         # Either upload user-provided inventory or create a default one
         if inventory is None:
             default_inventory_file = os.path.join(
@@ -345,7 +347,7 @@ class Host(Resource):
             inventory = inventory_on_host
         files.append(inventory)
 
-        # Upload other files with variables to be included in playbook execution
+        # Upload other variable files to be included in playbook execution
         if vars_files:
             vars_files_on_host = []
             for vars_file in vars_files:
@@ -383,7 +385,7 @@ class Host(Resource):
             io_timeout=io_timeout, follow_output=True,
         )
         self.logger.info(
-            "Ansible playbook with ID %s finished with RC %s", 
+            "Ansible playbook with ID %s finished with RC %s",
             executor.short_run_uuid, rc,
         )
 

--- a/rrmngmnt/package_manager.py
+++ b/rrmngmnt/package_manager.py
@@ -86,7 +86,7 @@ class PackageManager(Service):
             )
         cmd = self.list_command_d
         self.logger.debug(
-            "Getting all instaled packages from host %s", self.host
+            "Getting all installed packages from host %s", self.host
         )
         rc, out, err = self.host.executor().run_cmd(cmd)
         if not rc:

--- a/rrmngmnt/ssh.py
+++ b/rrmngmnt/ssh.py
@@ -122,7 +122,7 @@ class RemoteExecutor(Executor):
         def run_cmd(self, cmd, input_=None, timeout=None, follow_output=False):
             cmd = self.command(cmd)
             return (
-                cmd.run_real_time(timeout) if follow_output 
+                cmd.run_real_time(timeout) if follow_output
                 else cmd.run(input_, timeout)
             )
 
@@ -163,7 +163,9 @@ class RemoteExecutor(Executor):
             return self._rc
 
         @contextlib.contextmanager
-        def execute(self, bufsize=-1, timeout=None, get_pty=False, log_result=True):
+        def execute(
+            self, bufsize=-1, timeout=None, get_pty=False, log_result=True
+        ):
             """
             This method allows you to work directly with streams.
 
@@ -207,11 +209,11 @@ class RemoteExecutor(Executor):
                 self.out = normalize_string(out.read())
                 self.err = normalize_string(err.read())
             return self.rc, self.out, self.err
-        
+
         def run_real_time(self, timeout=None, get_pty=False):
             """
             This function executes command and continuously (line by line) logs
-            its output on debug level. 
+            its output on debug level.
             """
             with self.execute(
                 timeout=timeout, get_pty=get_pty, log_result=False
@@ -249,7 +251,10 @@ class RemoteExecutor(Executor):
         """
         return RemoteExecutor.Session(self, timeout)
 
-    def run_cmd(self, cmd, input_=None, tcp_timeout=None, io_timeout=None, follow_output=False):
+    def run_cmd(
+        self, cmd, input_=None, tcp_timeout=None,
+        io_timeout=None, follow_output=False
+    ):
         """
         Args:
             tcp_timeout (float): Tcp timeout
@@ -262,7 +267,7 @@ class RemoteExecutor(Executor):
             tuple (int, str, str): Rc, out, err
         """
         with self.session(tcp_timeout) as session:
-                return session.run_cmd(cmd, input_, io_timeout, follow_output)
+            return session.run_cmd(cmd, input_, io_timeout, follow_output)
 
     def is_connective(self, tcp_timeout=20.0):
         """
@@ -327,17 +332,17 @@ class PlaybookExecutor(RemoteExecutor):
           compliance with RFC 4122. This GUID is used to identify one specific
           execution of Ansible playbook. We'll be using only the first part of
           that GUID, which admittedly does not guarantee complete uniqueness.
-          But the chance of collision is so low that the benefir of having short
-          identifier outweights that risk.
+          But the chance of collision is so low that the benefir of having
+          short identifier outweights that risk.
         - RemoteExecutor usually instantiates its own logger (called
           RemoteExecutor by the class name) that has no handlers or formatters
           specified and that inherits them from a parent logger. This is also
           the default behavior of PlaybookExecutor. However, if we instantiated
           our Host object with playbook_logger, we can pass it to
-          PlaybookExecutorFactory and the resulting instance of PlaybookExecutor
-          will use that logger (along with its handlers and formatters) instead.
-          This is useful when you want to redirect Ansible output to other
-          destination than what your app's main logger logs to.
+          PlaybookExecutorFactory and the resulting instance of
+          PlaybookExecutor will use that logger (along with its handlers and
+          formatters) instead. This is useful when you want to redirect Ansible
+          output to other destination than what your app's main logger logs to.
         - We also provide different LoggerAdapter here. Its main purpose is to
           enrich emitted LogRecord with run's GUID.
     """
@@ -368,7 +373,7 @@ class PlaybookExecutor(RemoteExecutor):
         """
         def process(self, msg, kwargs):
             return (
-                "[%s] %s" % (self.extra['self'].short_run_uuid, msg), 
+                "[%s] %s" % (self.extra['self'].short_run_uuid, msg),
                 kwargs,
             )
 


### PR DESCRIPTION
The point of this pull request is to have dedicated function on `Host` that enables you to run Ansible playbooks remotely. The intended usage might look like this:

```python
REMOTE_HOST = resources.Host("10.1.2.3", playbook_logger=logging.getLogger('playbook'))

rc, out, err = REMOTE_HOST.run_playbook(
    playbook_path_local="/home/joe/setup_vm.yml",
    extra_vars={"vm_name": "joe-sandbox"},
    run_in_check_mode=False,
    vars_files="/home/joe/vars.yml",
    verbose_level=3,
    inventory="/home/joe/ansible_hosts",
)
```

Another point is that I also want to be able to capture output of remotely-run Ansible playbook into a log file that is separate from my application's main log file. That's why we can not instantiate `Host` object with optional `playbook_logger` parameter.

Also, I know that the current implementation is kind of bare bones and definitely does not take into consideration all the possible scenarios user might encounter. I plan to iterate on that in the future. If you can think of functionality that you'd like to see in here, please comment on it and I will create an issue. Or better yet, create the issue in `python-rrmngmngt` yourself. :-)