### PR TITLE
Add PlaybookRunner service

### DIFF
--- a/rrmngmnt/common.py
+++ b/rrmngmnt/common.py
@@ -37,3 +37,31 @@ def normalize_string(data):
     if isinstance(data, six.text_type):
         data = data.encode('utf-8', errors='replace')
     return data
+
+
+class CommandReader(object):
+
+    def __init__(self, executor, cmd, session_timeout=None, cmd_input=None):
+        self.executor = executor
+        self.cmd = cmd
+        self.session_timeout = session_timeout
+        self.cmd_input = cmd_input
+        self.rc = None
+        self.out = ''
+        self.err = ''
+
+    def read_lines(self):
+        with self.executor.session(self.session_timeout) as ss:
+            command = ss.command(self.cmd)
+            with command.execute() as (in_, out, err):
+                if self.cmd_input:
+                    in_.write(self.cmd_input)
+                    in_.close()
+                while True:
+                    line = out.readline()
+                    self.out += line
+                    if not line:
+                        break
+                    yield line.strip()
+                self.rc = command.rc
+                self.err = err.read()

--- a/rrmngmnt/executor.py
+++ b/rrmngmnt/executor.py
@@ -31,10 +31,6 @@ class Executor(Resource):
         def logger(self):
             return self._executor.logger
 
-        @property
-        def real_time_log(self):
-            return self._executor.real_time_log
-
         def __enter__(self):
             self.open()
             return self
@@ -67,10 +63,6 @@ class Executor(Resource):
         @property
         def logger(self):
             return self._ss.logger
-
-        @property
-        def real_time_log(self):
-            return self._ss.real_time_log
 
         def run(self, input_):
             raise NotImplementedError()

--- a/rrmngmnt/executor.py
+++ b/rrmngmnt/executor.py
@@ -31,6 +31,10 @@ class Executor(Resource):
         def logger(self):
             return self._executor.logger
 
+        @property
+        def real_time_log(self):
+            return self._executor.real_time_log
+
         def __enter__(self):
             self.open()
             return self
@@ -63,6 +67,10 @@ class Executor(Resource):
         @property
         def logger(self):
             return self._ss.logger
+
+        @property
+        def real_time_log(self):
+            return self._ss.real_time_log
 
         def run(self, input_):
             raise NotImplementedError()

--- a/rrmngmnt/host.py
+++ b/rrmngmnt/host.py
@@ -210,9 +210,7 @@ class Host(Resource):
     def power_manager(self):
         return self.get_power_manager()
 
-    def executor(
-        self, user=None, pkey=False, logger=None, real_time_log=False
-    ):
+    def executor(self, user=None, pkey=False):
         """
         Gives you executor to allowing command execution
 
@@ -231,9 +229,7 @@ class Host(Resource):
             ef = copy.copy(ssh.RemoteExecutorFactory)
             ef.use_pkey = pkey
             return ef(self.ip, user)
-        return self.executor_factory.build(
-            self, user, logger=logger, real_time_log=real_time_log
-        )
+        return self.executor_factory.build(self, user)
 
     def run_command(
         self, command, input_=None, tcp_timeout=None, io_timeout=None,

--- a/rrmngmnt/host.py
+++ b/rrmngmnt/host.py
@@ -19,6 +19,7 @@ from rrmngmnt.firewall import Firewall
 from rrmngmnt.network import Network
 from rrmngmnt.operatingsystem import OperatingSystem
 from rrmngmnt.package_manager import PackageManagerProxy
+from rrmngmnt.playbook_runner import PlaybookRunner
 from rrmngmnt.resource import Resource
 from rrmngmnt.service import Systemd, SysVinit, InitCtl
 from rrmngmnt.storage import NFSService, LVMService
@@ -209,7 +210,9 @@ class Host(Resource):
     def power_manager(self):
         return self.get_power_manager()
 
-    def executor(self, user=None, pkey=False):
+    def executor(
+        self, user=None, pkey=False, logger=None, real_time_log=False
+    ):
         """
         Gives you executor to allowing command execution
 
@@ -228,7 +231,9 @@ class Host(Resource):
             ef = copy.copy(ssh.RemoteExecutorFactory)
             ef.use_pkey = pkey
             return ef(self.ip, user)
-        return self.executor_factory.build(self, user)
+        return self.executor_factory.build(
+            self, user, logger=logger, real_time_log=real_time_log
+        )
 
     def run_command(
         self, command, input_=None, tcp_timeout=None, io_timeout=None,
@@ -459,6 +464,10 @@ class Host(Resource):
     @property
     def fs(self):
         return FileSystem(self)
+
+    @property
+    def playbook(self):
+        return PlaybookRunner(self)
 
     @property
     def ssh_public_key(self):

--- a/rrmngmnt/playbook_runner.py
+++ b/rrmngmnt/playbook_runner.py
@@ -1,0 +1,159 @@
+import contextlib
+import json
+import os.path
+import uuid
+
+from rrmngmnt.resource import Resource
+from rrmngmnt.service import Service
+
+
+# TODO: Add debug messages
+
+class PlaybookRunner(Service):
+
+    class PlaybookAdapter(Resource.LoggerAdapter):
+        def process(self, msg, kwargs):
+            return (
+                "[%s] %s" % (
+                    self.extra['self'].short_run_uuid,
+                    msg
+                ),
+                kwargs
+            )
+
+    tmp_dir = "/tmp"
+    binary = "ansible-playbook"
+    extra_vars_file = "extra_vars.json"
+    default_inventory_name = "inventory"
+    default_inventory_content = "localhost ansible_connection=local"
+    check_mode_param = "--check"
+
+    def __init__(self, host):
+        super(PlaybookRunner, self).__init__(host)
+        self.run_uuid = uuid.uuid4()
+        self.short_run_uuid = str(self.run_uuid).split('-')[0]
+        self.tmp_exec_dir = None
+        self.cmd = [self.binary]
+        self.rc = None
+        self.out = None
+        self.err = None
+
+    @contextlib.contextmanager
+    def _exec_dir(self):
+        # In temporary location, create a directory whose name is same
+        # as the short run UUID
+        exec_dir_path = os.path.join(self.tmp_dir, self.short_run_uuid)
+        self.host.fs.rmdir(exec_dir_path)
+        self.host.fs.mkdir(exec_dir_path)
+        self.tmp_exec_dir = exec_dir_path
+        try:
+            yield
+        finally:
+            self.tmp_exec_dir = None
+            self.host.fs.rmdir(exec_dir_path)
+
+    def _upload_file(self, file_):
+        file_path_on_host = os.path.join(
+            self.tmp_exec_dir, os.path.basename(file_)
+        )
+        self.host.fs.put(path_src=file_, path_dst=file_path_on_host)
+        return file_path_on_host
+
+    def _dump_vars_to_json(self, vars_):
+        file_path_on_host = os.path.join(
+            self.tmp_exec_dir, self.extra_vars_file
+        )
+        self.host.fs.create_file(
+            content=json.dumps(vars_), path=file_path_on_host
+        )
+        return file_path_on_host
+
+    def _generate_default_inventory(self):
+        file_path_on_host = os.path.join(
+            self.tmp_exec_dir, self.default_inventory_name
+        )
+        self.host.fs.create_file(
+            content=self.default_inventory_content,
+            path=file_path_on_host
+        )
+        return file_path_on_host
+
+    def run(
+        self, playbook, extra_vars=None, vars_files=None, inventory=None,
+        verbose_level=1, run_in_check_mode=False, playbook_logger=None
+    ):
+        """
+        Run Ansible playbook on host
+
+        Args:
+            playbook (str): Path to playbook you want to execute
+            extra_vars (dict): Dictionary of extra variables that are to be
+                passed to playbook execution. They will be dumped into JSON
+                file and included using -e@ parameter
+            vars_files (list): List of additional variable files to be included
+                using -e@ parameter. Variables specified in those files will
+                override those specified in extra_vars param
+            inventory (str): Path to an inventory file to be used for playbook
+                execution. If none is provided, default inventory including
+                only localhost will be generated and used
+            verbose_level (int): How much should playbook be verbose. Possible
+                values are 1 through 5 with 1 being the most quiet and 5 being
+                the most verbose
+            run_in_check_mode (bool): If True, playbook will not actually be
+                executed, but instead run with --check parameter
+            playbook_logger (logging.Logger): If you want to redirect output of
+                Ansible playbook to an alternate location, you can provide
+                instance of logging.Logger here. Your logger will be modified
+                by PlaybookAdapter which makes sure that each line of Ansible
+                output is matched with short run ID. If no logger is provided
+                here, RemoteExecutor logger will be used
+
+        Returns:
+            tuple: tuple of (rc, out, err)
+        """
+        with self._exec_dir():
+
+            if extra_vars:
+                self.cmd.append(
+                    "-e@{}".format(self._dump_vars_to_json(extra_vars))
+                )
+
+            if vars_files:
+                for f in vars_files:
+                    self.cmd.append("-e@{}".format(f))
+
+            self.cmd.append("-i")
+            if inventory:
+                self.cmd.append(self._upload_file(inventory))
+            else:
+                self.cmd.append(self._generate_default_inventory())
+
+            self.cmd.append("-{}".format("v" * verbose_level))
+
+            if run_in_check_mode:
+                self.cmd.append(self.check_mode_param)
+
+            self.cmd.append(self._upload_file(playbook))
+
+            self.logger.info(
+                "Executing: {}. Playbook run ID: {}".format(
+                    " ".join(self.cmd), self.short_run_uuid
+                )
+            )
+            if playbook_logger:
+                playbook_logger = self.PlaybookAdapter(
+                    playbook_logger,
+                    {'self': self}
+                )
+            self.rc, self.out, self.err = self.host.executor(
+                real_time_log=True,
+                logger=playbook_logger
+            ).run_cmd(self.cmd)
+
+            self.logger.info(
+                "Ansible playbook run with ID {} finished with RC: {}".format(
+                    self.short_run_uuid, self.rc
+                )
+            )
+
+        return self.rc, self.out, self.err

--- a/rrmngmnt/playbook_runner.py
+++ b/rrmngmnt/playbook_runner.py
@@ -122,7 +122,7 @@ class PlaybookRunner(Service):
 
             if vars_files:
                 for f in vars_files:
-                    self.cmd.append("-e@{}".format(f))
+                    self.cmd.append("-e@{}".format(self._upload_file(f)))
 
             self.cmd.append("-i")
             if inventory:

--- a/rrmngmnt/resource.py
+++ b/rrmngmnt/resource.py
@@ -16,8 +16,14 @@ class Resource(object):
     def __init__(self):
         super(Resource, self).__init__()
         logger = logging.getLogger(self.__class__.__name__)
-        self._logger_adapter = self.LoggerAdapter(logger, {'self': self})
+        self.set_logger(logger)
 
     @property
     def logger(self):
         return self._logger_adapter
+
+    def set_logger(self, logger):
+        if isinstance(logger, logging.Logger):
+            self._logger_adapter = self.LoggerAdapter(logger, {'self': self})
+        elif isinstance(logger, logging.LoggerAdapter):
+            self._logger_adapter = logger

--- a/rrmngmnt/ssh.py
+++ b/rrmngmnt/ssh.py
@@ -21,12 +21,12 @@ class RemoteExecutor(Executor):
     Any resource which provides SSH service.
 
     This class is meant to replace our current utilities.machine.LinuxMachine
-    classs. This allows you to lower access to communicate with ssh.
+    class. This allows you to lower access to communicate with ssh.
     Like a live interaction, getting rid of True/False results, and
     mixing stdout with stderr.
 
     You can still use use 'run_cmd' method if you don't care.
-    But I would recommed you to work like this:
+    But I would recommend you to work like this:
     """
 
     TCP_TIMEOUT = 10.0

--- a/rrmngmnt/ssh.py
+++ b/rrmngmnt/ssh.py
@@ -188,8 +188,7 @@ class RemoteExecutor(Executor):
                 if self._err is not None:
                     self._err.close()
                 self.logger.debug("Results of command: %s", self.cmd)
-                if not self.real_time_log:
-                    self.logger.debug("  OUT: %s", self.out)
+                self.logger.debug("  OUT: %s", self.out)
                 self.logger.debug("  ERR: %s", self.err)
                 self.logger.debug("  RC: %s", self.rc)
 
@@ -200,23 +199,11 @@ class RemoteExecutor(Executor):
                 if input_:
                     in_.write(input_)
                     in_.close()
-                if self.real_time_log:
-                    captured_out = ""
-                    for line in iter(out.readline, ""):
-                        captured_out += line
-                        self.logger.debug(line.rstrip('\n'))
-                    self.logger.debug('')
-                self.out = (
-                    normalize_string(out.read()) if not self.real_time_log
-                    else normalize_string(captured_out)
-                )
+                self.out = normalize_string(out.read())
                 self.err = normalize_string(err.read())
             return self.rc, self.out, self.err
 
-    def __init__(
-        self, user, address, use_pkey=False, port=22,
-        logger=None, real_time_log=False
-    ):
+    def __init__(self, user, address, use_pkey=False, port=22):
         """
         Args:
             use_pkey (bool): Use ssh private key in the connection
@@ -228,9 +215,6 @@ class RemoteExecutor(Executor):
         self.address = address
         self.use_pkey = use_pkey
         self.port = port
-        if logger is not None:
-            self.set_logger(logger)
-        self.real_time_log = real_time_log
 
     def session(self, timeout=None):
         """
@@ -315,8 +299,6 @@ class RemoteExecutorFactory(ExecutorFactory):
         self.use_pkey = use_pkey
         self.port = port
 
-    def build(self, host, user, logger, real_time_log):
+    def build(self, host, user):
         return RemoteExecutor(
-            user, host.ip, use_pkey=self.use_pkey,
-            port=self.port, logger=logger, real_time_log=real_time_log
-        )
+            user, host.ip, use_pkey=self.use_pkey, port=self.port)

--- a/tests/common.py
+++ b/tests/common.py
@@ -106,8 +106,8 @@ class FakeExecutor(Executor):
         @contextlib.contextmanager
         def execute(self, bufsize=-1, timeout=None):
             rc, out, err = self._ss.get_data(self.cmd)
-            yield six.StringIO(), six.StringIO(out), six.StringIO(err)
             self._rc = rc
+            yield six.StringIO(), six.StringIO(out), six.StringIO(err)
 
     def __init__(self, user, address):
         super(FakeExecutor, self).__init__(user)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -19,11 +19,12 @@ def test_fqdn2ip_negative():
 
 
 class TestCommandReader(object):
+
     data = {
         'cat shopping_list.txt': (0, 'bananas\nmilk\nhuge blender', ''),
         'cat milk_shake_recipe.txt': (
-            1, '',
-            'cat: milk_shake_recipe.txt: No such file or directory'),
+            1, '', 'cat: milk_shake_recipe.txt: No such file or directory'
+        ),
     }
     files = {}
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import types
+
 import pytest
 import netaddr
-from rrmngmnt import common
+from rrmngmnt import common, Host, User
+from .common import FakeExecutorFactory
 
 
 def test_fqdn2ip_positive():
@@ -13,3 +16,75 @@ def test_fqdn2ip_negative():
     with pytest.raises(Exception) as ex_info:
         common.fqdn2ip('github.or')
     assert 'github.or' in str(ex_info.value)
+
+
+class TestCommandReader(object):
+    data = {
+        'cat shopping_list.txt': (0, 'bananas\nmilk\nhuge blender', ''),
+        'cat milk_shake_recipe.txt': (
+            1, '',
+            'cat: milk_shake_recipe.txt: No such file or directory'),
+    }
+    files = {}
+
+    @classmethod
+    @pytest.fixture(scope='class')
+    def fake_host(cls):
+        fh = Host('1.1.1.1')
+        fh.add_user(User('root', '11111'))
+        fh.executor_factory = FakeExecutorFactory(cls.data, cls.files)
+        return fh
+
+    def test_return_type(self, fake_host):
+        """ Test that CommandReader returns generator type """
+        cmd = 'cat shopping_list.txt'
+        cmd_reader = common.CommandReader(fake_host.executor(), cmd.split())
+        ret = cmd_reader.read_lines()
+
+        assert isinstance(ret, types.GeneratorType)
+
+        expected_output = self.data[cmd][1].split('\n')
+        for i in range(len(expected_output)):
+            assert next(ret) == expected_output[i]
+
+        with pytest.raises(StopIteration):
+            next(ret)
+
+    def test_iterate_over_output(self, fake_host):
+        """
+        Test that we can iterate over CommandReader's output using for loop
+        """
+        cmd = 'cat shopping_list.txt'
+        cmd_reader = common.CommandReader(fake_host.executor(), cmd.split())
+        expected_output = self.data[cmd][1].split('\n')
+        cmd_reader_output = []
+
+        for line in cmd_reader.read_lines():
+            cmd_reader_output.append(line)
+
+        assert cmd_reader_output == expected_output
+
+    def test_return_code(self, fake_host):
+        """ Test that rc of command is captured by CommandReader """
+        cmd = 'cat shopping_list.txt'
+        cmd_reader = common.CommandReader(fake_host.executor(), cmd.split())
+
+        assert cmd_reader.rc is None
+
+        for line in cmd_reader.read_lines():
+            pass
+
+        assert not cmd_reader.rc
+
+    def test_stderr(self, fake_host):
+        """ Test that error output is captured by CommandReader """
+        cmd = 'cat milk_shake_recipe.txt'
+        cmd_reader = common.CommandReader(fake_host.executor(), cmd.split())
+
+        assert not cmd_reader.err
+
+        for line in cmd_reader.read_lines():
+            pass
+
+        assert cmd_reader.rc
+        assert cmd_reader.err

--- a/tests/test_playbook_runner.py
+++ b/tests/test_playbook_runner.py
@@ -1,0 +1,233 @@
+import os.path
+
+import pytest
+
+from rrmngmnt import Host, User
+from rrmngmnt.playbook_runner import PlaybookRunner
+from .common import FakeExecutorFactory
+
+
+class PlaybookRunnerBase(object):
+
+    # The fake run UUID will be used instead of unique ID that's auto-generated
+    # for each playbook execution
+    fake_run_uuid = '123'
+    playbook_name = 'test.yml'
+    playbook_content = ''
+    vars_file_name = 'my_vars.yml'
+    vars_file_content = ''
+    inventory_name = 'my_inventory'
+    inventory_content = ''
+    success = (0, '', '')
+    failure = (1, '', '')
+    tmp_dir = os.path.join(PlaybookRunner.tmp_dir, fake_run_uuid)
+
+    data = {
+        # Filesystem-related operations
+        'rm -rf {}'.format(tmp_dir): success,
+        'mkdir {}'.format(tmp_dir): success,
+        '[ -d {tmp_dir}/{playbook} ]'.format(
+            tmp_dir=tmp_dir, playbook=playbook_name
+        ): failure,
+        '[ -d {tmp_dir}/{vars_file} ]'.format(
+            tmp_dir=tmp_dir, vars_file=vars_file_name
+        ): failure,
+        '[ -d {tmp_dir}/{inventory} ]'.format(
+            tmp_dir=tmp_dir, inventory=inventory_name
+        ): failure,
+        # Actual execution of ansible-playbook
+        # Basic scenario
+        '{bin} -i {tmp_dir}/{inventory} -v {tmp_dir}/{playbook}'.format(
+            bin=PlaybookRunner.binary,
+            tmp_dir=tmp_dir,
+            inventory=PlaybookRunner.default_inventory_name,
+            playbook=playbook_name
+        ): success,
+        # Extra vars have been provided
+        '{bin} -e@{tmp_dir}/{extra_vars} -i {tmp_dir}/{inventory} '
+        '-v {tmp_dir}/{playbook}'.format(
+            bin=PlaybookRunner.binary,
+            extra_vars=PlaybookRunner.extra_vars_file,
+            tmp_dir=tmp_dir,
+            inventory=PlaybookRunner.default_inventory_name,
+            playbook=playbook_name
+        ): success,
+        # File with additional variables has been provided
+        '{bin} -e@{tmp_dir}/{vars_file} -i {tmp_dir}/{inventory} '
+        '-v {tmp_dir}/{playbook}'.format(
+            bin=PlaybookRunner.binary,
+            vars_file=vars_file_name,
+            tmp_dir=tmp_dir,
+            inventory=PlaybookRunner.default_inventory_name,
+            playbook=playbook_name
+        ): success,
+        # Custom inventory has been provided
+        '{bin} -i {tmp_dir}/{inventory} -v {tmp_dir}/{playbook}'.format(
+            bin=PlaybookRunner.binary,
+            tmp_dir=tmp_dir,
+            inventory=inventory_name,
+            playbook=playbook_name
+        ): success,
+        # Verbosity has been increased to max
+        '{bin} -i {tmp_dir}/{inventory} -vvvvv {tmp_dir}/{playbook}'.format(
+            bin=PlaybookRunner.binary,
+            tmp_dir=tmp_dir,
+            inventory=PlaybookRunner.default_inventory_name,
+            playbook=playbook_name
+        ): success,
+        # Running in check mode
+        '{bin} -i {tmp_dir}/{inventory} -v {check_mode_param} '
+        '{tmp_dir}/{playbook}'.format(
+            bin=PlaybookRunner.binary,
+            tmp_dir=tmp_dir,
+            inventory=PlaybookRunner.default_inventory_name,
+            check_mode_param=PlaybookRunner.check_mode_param,
+            playbook=playbook_name
+        ): success,
+    }
+
+    @classmethod
+    @pytest.fixture(scope='class')
+    def fake_host(cls):
+        fh = Host('1.1.1.1')
+        fh.add_user(User('root', '11111'))
+        fh.executor_factory = FakeExecutorFactory(cls.data, cls.files)
+        return fh
+
+    @pytest.fixture()
+    def fake_playbook(self, tmpdir):
+        fp = tmpdir.join(self.playbook_name)
+        fp.write(self.playbook_content)
+        return str(fp)
+
+    @pytest.fixture()
+    def playbook_runner(self, fake_host):
+        playbook_runner = PlaybookRunner(fake_host)
+        playbook_runner.short_run_uuid = self.fake_run_uuid
+        return playbook_runner
+
+    def check_files_on_host(self, files=None):
+        if files is None:
+            files = []
+        if isinstance(files, str):
+            files = [files]
+        expected_files = [os.path.join(self.tmp_dir, self.playbook_name)]
+        expected_files.extend(files)
+        return sorted(expected_files) == sorted(list(self.files.keys()))
+
+
+class TestBasic(PlaybookRunnerBase):
+
+    files = {}
+
+    def test_basic_scenario(self, playbook_runner, fake_playbook):
+        """ User has provided only playbook """
+        rc, _, _ = playbook_runner.run(playbook=fake_playbook)
+        assert not rc
+        assert self.check_files_on_host(
+            os.path.join(self.tmp_dir, PlaybookRunner.default_inventory_name)
+        )
+
+
+class TestExtraVars(PlaybookRunnerBase):
+
+    files = {}
+
+    def test_extra_vars(self, playbook_runner, fake_playbook):
+        """ User has provided extra vars as a dictionary """
+        rc, _, _ = playbook_runner.run(
+            playbook=fake_playbook,
+            extra_vars={
+                "greetings": "hello",
+            }
+        )
+        assert not rc
+        assert self.check_files_on_host(
+            [
+                os.path.join(
+                    self.tmp_dir, PlaybookRunner.default_inventory_name
+                ),
+                os.path.join(self.tmp_dir, PlaybookRunner.extra_vars_file)
+            ]
+        )
+
+
+class TestVarsFile(PlaybookRunnerBase):
+
+    files = {}
+
+    @pytest.fixture()
+    def fake_vars_file(self, tmpdir):
+        fvf = tmpdir.join(self.vars_file_name)
+        fvf.write(self.vars_file_content)
+        return str(fvf)
+
+    def test_vars_file(self, playbook_runner, fake_playbook, fake_vars_file):
+        """ User has provided YAML file with custom variables """
+        rc, _, _ = playbook_runner.run(
+            playbook=fake_playbook,
+            vars_files=[fake_vars_file]
+        )
+        assert not rc
+        assert self.check_files_on_host(
+            [
+                os.path.join(
+                    self.tmp_dir, PlaybookRunner.default_inventory_name
+                ),
+                os.path.join(self.tmp_dir, self.vars_file_name)
+            ]
+        )
+
+
+class TestInventory(PlaybookRunnerBase):
+
+    files = {}
+
+    @pytest.fixture()
+    def fake_inventory(self, tmpdir):
+        fi = tmpdir.join(self.inventory_name)
+        fi.write(self.inventory_content)
+        return str(fi)
+
+    def test_inventory(self, playbook_runner, fake_playbook, fake_inventory):
+        """ User has provided custom inventory instead of the default one """
+        rc, _, _ = playbook_runner.run(
+            playbook=fake_playbook,
+            inventory=fake_inventory
+        )
+        assert not rc
+        assert self.check_files_on_host(
+            os.path.join(self.tmp_dir, self.inventory_name)
+        )
+
+
+class TestVerbosity(PlaybookRunnerBase):
+
+    files = {}
+
+    def test_max_verbosity(self, playbook_runner, fake_playbook):
+        """ User has increased verbosity to maximum level """
+        rc, _, _ = playbook_runner.run(
+            playbook=fake_playbook,
+            verbose_level=5
+        )
+        assert not rc
+        assert self.check_files_on_host(
+            os.path.join(self.tmp_dir, PlaybookRunner.default_inventory_name)
+        )
+
+
+class TestCheckMode(PlaybookRunnerBase):
+
+    files = {}
+
+    def test_check_mode(self, playbook_runner, fake_playbook):
+        """ User is running the playbook with --check param """
+        rc, _, _ = playbook_runner.run(
+            playbook=fake_playbook,
+            run_in_check_mode=True
+        )
+        assert not rc
+        assert self.check_files_on_host(
+            os.path.join(self.tmp_dir, PlaybookRunner.default_inventory_name)
+        )

--- a/tests/test_playbook_runner.py
+++ b/tests/test_playbook_runner.py
@@ -18,9 +18,9 @@ class PlaybookRunnerBase(object):
     vars_file_content = ''
     inventory_name = 'my_inventory'
     inventory_content = ''
+    tmp_dir = os.path.join(PlaybookRunner.tmp_dir, fake_run_uuid)
     success = (0, '', '')
     failure = (1, '', '')
-    tmp_dir = os.path.join(PlaybookRunner.tmp_dir, fake_run_uuid)
 
     data = {
         # Filesystem-related operations
@@ -107,6 +107,25 @@ class PlaybookRunnerBase(object):
         return playbook_runner
 
     def check_files_on_host(self, files=None):
+        """
+        Check that all files provided to files parameter (and only those) have
+        been "copied" to our imaginary host. In reality, they should not be
+        present on host once the playbook's execution is done. However here
+        we'll use the fact that our fake host does not really implements file
+        removal. Because of this, in the end of the test case, we can check
+        that files that should have been copied to the host (by using
+        FileSystem service) have actually been sent there.
+
+        Args:
+            files (list): List of files that should have been copied to the
+                host. Don't include test playbook into this list since its
+                presence is implicitly expected. You can also provide only one
+                file as a string.
+
+        Returns:
+            bool: True if files expected on host and those present match, False
+                otherwise
+        """
         if files is None:
             files = []
         if isinstance(files, str):


### PR DESCRIPTION
This pull request adds a new service to python-rrmngmt along already existing services like `FileSystem`, `PackageManager` or `Firewall`. Its name is `PlaybookRunner` and its main use is to execute Ansible playbooks on (most often remote) hosts. It also has some additional functionality:
* Copy the playbook to host
* Copy all additional files required for playbook execution
* Use user-provided inventory or generate a default one
* Let user specify extra vars as a python dictionary and include them into playbook execution
* Let user set verbosity and check mode for ansible-playbook
* Use default `PlaybookRunner` logger by default or let user provide custom logger
* Log ansible-playbook output lines as soon as they come in as opposed to waiting for command's completion which is the case with `Host.run_command`

To achieve the last point, I also added `common.CommandReader` class. During your review, please keep in mind that:
* I've already agreed on this implementation with @lukas-bednar and I am not going to change its essence unless some fatal problem with it is found
* I am not going to add any additional functionality in the scope of this PR