### PR TITLE
Added an API to nmcli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 python:
 - '2.7'
-- '3.4'
 - '3.5'
 - '3.6'
 install:

--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -142,10 +142,12 @@ class Network(Service):
         super(Network, self).__init__(host)
         self._m = _session(host)
         self._hnh = None
-        self._nmcli = NMCLI(host)
+        self._nmcli = None
 
     @property
     def nmcli(self):
+        if self.nmcli is None:
+            self._nmcli = NMCLI(self.host)
         return self._nmcli
 
     @keep_session

--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -6,6 +6,7 @@ import shlex
 import six
 import subprocess
 from rrmngmnt.errors import CommandExecutionFailure
+from rrmngmnt.nmcli import NMCLI
 
 from rrmngmnt.service import Service
 
@@ -141,6 +142,11 @@ class Network(Service):
         super(Network, self).__init__(host)
         self._m = _session(host)
         self._hnh = None
+        self._nmcli = NMCLI(host)
+
+    @property
+    def nmcli(self):
+        return self._nmcli
 
     @keep_session
     def _cmd(self, cmd):

--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -146,7 +146,7 @@ class Network(Service):
 
     @property
     def nmcli(self):
-        if self.nmcli is None:
+        if self._nmcli is None:
             self._nmcli = NMCLI(self.host)
         return self._nmcli
 

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -531,6 +531,36 @@ class NMCLI(Service):
 
         self._exec_command(command=command)
 
+    def modify_connection(self, connection, properties):
+        """
+        Modifies a connection.
+
+        Args:
+            connection (str): name, UUID or path.
+            properties (dict): properties mapping to values
+
+        Raises:
+            ConnectionDoesNotExistException: if a connection with the given
+                name does not exist.
+            CommandExecutionFailure: if the remote host returned a code
+                indicating a failure in execution.
+
+        Notes:
+            For multi-value properties e.g: ipv4.addresses, it is possible to
+            pass a property key with a '+' prefix to append a value e.g:
+            {"+ipv4.addresses": "192.168.23.2"}, or a '-' in order to remove
+            a property.
+        """
+        if not self.is_connection_exist(connection=connection):
+            raise ConnectionDoesNotExistException(connection)
+
+        command = "nmcli connection modify {con}".format(con=connection)
+
+        for prop, val in properties.items():
+            command += " " + prop + " " + val
+
+        self._exec_command(command=command)
+
     def delete_connection(self, connection):
         """
         Deletes a connection.
@@ -540,7 +570,7 @@ class NMCLI(Service):
 
         Raises:
             ConnectionDoesNotExistException: if a connection with the given
-            name does not exist.
+                name does not exist.
         """
         if self.is_connection_exist(connection=connection):
             self._exec_command(
@@ -550,14 +580,14 @@ class NMCLI(Service):
             raise ConnectionDoesNotExistException(connection)
 
     def _extend_add_command(
-            self,
-            ipv4_addr,
-            ipv4_gw,
-            ipv4_method,
-            ipv6_addr,
-            ipv6_gw,
-            ipv6_method,
-            mtu
+        self,
+        ipv4_addr,
+        ipv4_gw,
+        ipv4_method,
+        ipv6_addr,
+        ipv6_gw,
+        ipv6_method,
+        mtu
     ):
         """
         Extends a connection adding command with optional parameters.

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -3,12 +3,11 @@
 This module introduces support for the nmcli command which is provided by
 NetworkManager.
 """
-import logging
 import shlex
 
 import netaddr
 
-from rrmngmnt.errors import CommandExecutionFailure
+from rrmngmnt.errors import CommandExecutionFailure, GeneralResourceError
 from rrmngmnt.service import Service
 
 IPV4_STATIC = "ipv4.addresses {address} ipv4.gateway {gateway}"
@@ -39,8 +38,6 @@ NMCLI_CONNECTION_DELETE = "nmcli connection delete {id}"
 
 NMCLI_CONNECTION_ADD = "nmcli connection add"
 
-logger = logging.getLogger(__name__)
-
 
 class NMCLI(Service):
     """
@@ -70,7 +67,7 @@ class NMCLI(Service):
         rc, out, err = self._executor.run_cmd(split)
 
         if rc != 0:
-            logger.error(
+            self.logger.error(
                 ERROR_MSG_FORMAT.format(command=command, rc=rc, out=out, err=err)  # noqa: E501
             )
             raise CommandExecutionFailure(
@@ -703,7 +700,7 @@ class NMCLI(Service):
             return netaddr.IPAddress(addr=ip_address).version
 
 
-class ConnectionDoesNotExistException(Exception):
+class ConnectionDoesNotExistException(GeneralResourceError):
     def __init__(self, con_name):
         super(ConnectionDoesNotExistException, self).__init__(con_name)
         self.con_name = con_name
@@ -712,7 +709,7 @@ class ConnectionDoesNotExistException(Exception):
         return "connection {con} does not exist".format(con=self.con_name)
 
 
-class DeviceDoesNotExistException(Exception):
+class DeviceDoesNotExistException(GeneralResourceError):
     def __init__(self, device):
         super(DeviceDoesNotExistException, self).__init__(device)
         self.device = device
@@ -721,7 +718,7 @@ class DeviceDoesNotExistException(Exception):
         return "device {dev} does not exist".format(dev=self.device)
 
 
-class InvalidIPException(Exception):
+class InvalidIPException(GeneralResourceError):
     def __init__(self, ip):
         super(InvalidIPException, self).__init__(ip)
         self.ip = ip
@@ -730,7 +727,7 @@ class InvalidIPException(Exception):
         return "IP address {addr} is in-valid".format(addr=self.ip)
 
 
-class InvalidMACException(Exception):
+class InvalidMACException(GeneralResourceError):
     def __init__(self, mac):
         super(InvalidMACException, self).__init__(mac)
         self.mac = mac

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -676,14 +676,14 @@ class NMCLI(Service):
             return "yes" if value is True else "no"
 
         common_options = (
-            "type {type} " "con-name {con_name} " "ifname {ifname} "
+            "type {type} con-name {con_name} ifname {ifname}"
         ).format(type=con_type, con_name=con_name, ifname=ifname)
         if auto_connect is not None:
-            common_options += "autoconnect {value}".format(
+            common_options += " autoconnect {value}".format(
                 value=_get_str_value(value=auto_connect)
             )
         if save is not None:
-            common_options += "save {value}".format(
+            common_options += " save {value}".format(
                 value=_get_str_value(value=save)
             )
 

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -1,0 +1,622 @@
+# -*- coding: utf-8 -*-
+"""
+This module introduces support for the nmcli command which is provided by
+NetworkManager.
+"""
+import logging
+import shlex
+
+from rrmngmnt.errors import CommandExecutionFailure
+from rrmngmnt.service import Service
+
+IPV4_STATIC = "ipv4.addresses {address} ipv4.gateway {gateway}"
+IPV6_STATIC = "ipv6.addresses {address} ipv6.gateway {gateway}"
+
+_IP_METHOD = "ipv{version}.method {method}"
+IPV4_METHOD = _IP_METHOD.format(version=4)
+IPV6_METHOD = _IP_METHOD.format(version=6)
+
+COMMON_OPTIONS = (
+    "type {type}"
+    "con-name {con_name} "
+    "ifname {ifname} "
+    "autoconnect {auto_connect} "
+    "save {save}"
+)
+
+IP_MANUAL_METHOD = "manual"
+
+DEFAULT_BOND_MODE = "active-backup"
+
+DEFAULT_MIIMON = 100
+
+ERROR_MSG_FORMAT = (
+    "command -> {command}\nRC -> {rc}\nOUT -> {out}\nERROR -> {err}"
+)
+
+NMCLI_COMMAND = "nmcli {options} {object} {command}"
+NMCLI_CONNECTION = "nmcli connection"
+NMCLI_CONNECTION_DELETE = NMCLI_CONNECTION + " delete {id}"
+NMCLI_CONNECTION_ADD = "nmcli connection add"
+
+logger = logging.getLogger(__name__)
+
+
+class NMCLI(Service):
+    """
+    This class implements network operations using nmcli.
+    """
+    def __init__(self, host):
+        super(NMCLI, self).__init__(host)
+        self._executor = host.executor()
+
+    def _exec_command(self, command):
+        """
+        Executes a command on the remote host.
+
+        Args:
+            command (str): a command to run remotely.
+
+        Returns:
+            str: command execution output.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+        """
+        split = shlex.split(command)
+
+        rc, out, err = self._executor.run_cmd(split)
+
+        if rc != 0:
+            logger.error(
+                ERROR_MSG_FORMAT.format(
+                    command=command,
+                    rc=rc,
+                    out=out,
+                    err=err)
+            )
+            raise CommandExecutionFailure(
+                executor=self._executor,
+                cmd=split,
+                rc=rc,
+                err=err
+            )
+        return out
+
+    def is_connection_exist(self, connection):
+        """
+        Checks if a connection exists.
+
+        Args:
+            connection (str):  name, UUID or path.
+
+        Returns:
+            bool: True if the connection exists, or False if it does not.
+        """
+        command = "nmcli connection show {con}".format(con=connection)
+        try:
+            self._exec_command(command=command)
+        except CommandExecutionFailure:
+            return False
+        return True
+
+    def get_connections_uuids(self):
+        """
+        Gets existing NetworkManager profiles UUIDs.
+
+        Returns:
+            list[str]: all connection UUIDs.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+        """
+        command = NMCLI_COMMAND.format(
+            options="-m multiline",
+            object="connection",
+            command="show"
+        )
+        out = self._exec_command(command=command)
+        con_names = [
+            line.strip("NAME:").strip() for line in out.splitlines()
+            if "NAME:" in line
+        ]
+        return [self.get_connection_uuid(con_name=name) for name in con_names]
+
+    def get_connection_uuid(self, con_name):
+        """
+        Gets a connection's UUID by the connection's name.
+
+        Args:
+            con_name (str): the connection's name.
+
+        Returns:
+            str: the connection's UUID.
+
+        Raises:
+            ConnectionDoesNotExistException: if a connection with the given
+            name does not exist.
+        """
+        if self.is_connection_exist(connection=con_name):
+            return self._exec_command(
+                command=NMCLI_COMMAND.format(
+                    options="-g connection.uuid",
+                    object="connection",
+                    command="show {con}".format(con=con_name)
+                )
+            ).strip()
+        raise ConnectionDoesNotExistException(con_name)
+
+    def get_device_type(self, device):
+        """
+        Gets the device type.
+
+        Args:
+            device (str): device name.
+
+        Returns:
+            str: the device type.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+        """
+        return self._exec_command(
+            command=NMCLI_COMMAND.format(
+                options="-g GENERAL.TYPE",
+                object="device",
+                command="show {device}".format(device=device)
+            )
+        ).strip()
+
+    def set_connection_state(self, connection, state):
+        """
+        Sets a connection's state.
+
+        Args:
+            connection (str): name, UUID or path.
+            state (str): the desired state.
+                available states are: ["up", "down"].
+
+        Raises:
+            ConnectionDoesNotExistException: if a connection with the given
+            name does not exist.
+        """
+        command = "nmcli connection {state} {con}".format(
+            state=state,
+            con=connection
+        )
+        if self.is_connection_exist(connection=connection):
+            self._exec_command(command=command)
+        raise ConnectionDoesNotExistException(connection)
+
+    def add_ethernet(
+            self,
+            con_name,
+            ifname,
+            auto_connect=False,
+            save=False,
+            mac=None,
+            mtu=None,
+            ipv4_method=None,
+            ipv4_addr=None,
+            ipv4_gw=None,
+            ipv6_method=None,
+            ipv6_addr=None,
+            ipv6_gw=None
+    ):
+        """
+        Creates an ETHERNET connection.
+
+        Args:
+            con_name (str): the created connection's name.
+            ifname (str): the interface name to use.
+            auto_connect (bool): True to connect automatically, or False for
+                manual.
+            save (bool): True to persist the connection, or False.
+            mac (str): MAC address to set for the connection.
+            mtu (int): MTU to set for the connection.
+            ipv4_method (str): setting method.
+                Available methods: auto, disabled, link-local, manual, shared.
+            ipv4_addr (str): a static address.
+            ipv4_gw (str): a gateway address.
+            ipv6_method (str): setting method.
+                Available methods: auto, dhcp, disabled, ignore, link-local,
+                manual, shared.
+            ipv6_addr (str): a static address.
+            ipv6_gw (str): a gateway address.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+        """
+        common_options = self._generate_common_options(
+            con_type="ethernet",
+            con_name=con_name,
+            ifname=ifname,
+            auto_connect=auto_connect,
+            save=save
+        )
+
+        command = NMCLI_CONNECTION_ADD + " " + common_options
+
+        if mac:
+            command += " mac {mac}".format(mac=mac)
+        if mtu:
+            command += " mtu {mtu}".format(mtu=mtu)
+
+        if ipv4_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv4_method,
+                address=ipv4_addr,
+                gateway=ipv4_gw,
+                version=4
+            )
+        if ipv6_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv6_method,
+                address=ipv6_addr,
+                gateway=ipv6_gw,
+                version=6
+            )
+
+        self._exec_command(command=command)
+
+    def add_bond(
+            self,
+            con_name,
+            ifname,
+            mode=DEFAULT_BOND_MODE,
+            miimon=DEFAULT_MIIMON,
+            auto_connect=False,
+            save=False,
+            ipv4_method=None,
+            ipv4_addr=None,
+            ipv4_gw=None,
+            ipv6_method=None,
+            ipv6_addr=None,
+            ipv6_gw=None
+    ):
+        """
+        Creates a bond connection.
+
+        Args:
+            con_name (str): the created connection's name.
+            ifname (str): the created bond's name.
+            mode (str): bond mode.
+                Available modes are: mode balance-rr (0) | active-backup (1) |
+                balance-xor (2) | broadcast (3)
+                802.3ad (4) | balance-tlb (5) | balance-alb (6)
+            miimon (int): specifies (in milliseconds) how often MII link
+                monitoring occurs.
+            auto_connect (bool): True to connect automatically, or False for
+                manual.
+            save (bool): True to persist the connection, or False.
+            ipv4_method (str): setting method.
+                Available methods: auto, disabled, link-local, manual, shared.
+            ipv4_addr (str): a static address.
+            ipv4_gw (str): a gateway address.
+            ipv6_method (str): setting method.
+                Available methods: auto, dhcp, disabled, ignore, link-local,
+                manual, shared.
+            ipv6_addr (str): a static address.
+            ipv6_gw (str): a gateway address.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+
+        Notes:
+            The parameters [ipv4_addr, ipv4_gw, ipv6_addr, ipv6_gw] are to be
+            used with a 'manual' IP method respectively.
+        """
+        common_options = self._generate_common_options(
+            con_type="bond",
+            con_name=con_name,
+            ifname=ifname,
+            auto_connect=auto_connect,
+            save=save
+        )
+
+        type_options = "mode {mode} miimon {miimon}".format(
+            mode=mode, miimon=miimon
+        )
+
+        command = (
+                NMCLI_CONNECTION_ADD
+                + " "
+                + common_options
+                + " "
+                + type_options
+        )
+
+        if ipv4_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv4_method,
+                address=ipv4_addr,
+                gateway=ipv4_gw,
+                version=4
+            )
+        if ipv6_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv6_method,
+                address=ipv6_addr,
+                gateway=ipv6_gw,
+                version=6
+            )
+
+        self._exec_command(command=command)
+
+    def add_slave(
+            self,
+            con_name,
+            ifname,
+            master,
+            auto_connect=False,
+            save=False
+    ):
+        """
+        Creates a bond slave.
+
+        Args:
+            con_name (str): the created connection's name.
+            ifname (str): the created bond's name.
+            master (str): ifname, connection UUID or name.
+            auto_connect (bool): True to connect automatically, or False for
+                manual.
+            save (bool): True to persist the connection, or False.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+        """
+        slave_type = self.get_device_type(device=ifname)
+
+        common_options = self._generate_common_options(
+            con_type=slave_type,
+            con_name=con_name,
+            ifname=ifname,
+            auto_connect=auto_connect,
+            save=save
+        )
+
+        command = (
+                NMCLI_CONNECTION_ADD
+                + " "
+                + common_options
+                + " master {master}".format(master=master)
+        )
+
+        self._exec_command(command=command)
+
+    def add_vlan(
+            self,
+            con_name,
+            dev,
+            vlan_id,
+            auto_connect=False,
+            save=False,
+            mtu=None,
+            ipv4_method=None,
+            ipv4_addr=None,
+            ipv4_gw=None,
+            ipv6_method=None,
+            ipv6_addr=None,
+            ipv6_gw=None
+    ):
+        """
+        Creates a VLAN connection.
+
+        Args:
+            con_name (str): the created connection's name.
+            dev (str): parent device.
+            vlan_id (int): VLAN ID.
+            auto_connect (bool): True to connect automatically, or False for
+                manual.
+            save (bool): True to persist the connection, or False.
+            mtu (int): MTU to set for the connection.
+            ipv4_method (str): setting method.
+                Available methods: auto, disabled, link-local, manual, shared.
+            ipv4_addr (str): a static address.
+            ipv4_gw (str): a gateway address.
+            ipv6_method (str): setting method.
+                Available methods: auto, dhcp, disabled, ignore, link-local,
+                manual, shared.
+            ipv6_addr (str): a static address.
+            ipv6_gw (str): a gateway address.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+        """
+        common_options = self._generate_common_options(
+            con_type="vlan",
+            con_name=con_name,
+            ifname=dev,
+            auto_connect=auto_connect,
+            save=save
+        )
+
+        command = (
+                NMCLI_CONNECTION_ADD
+                + " "
+                + common_options
+                + " dev {dev}".format(dev=dev)
+                + " id {id}".format(id=vlan_id)
+        )
+
+        if mtu:
+            command += " mtu {mtu}".format(mtu=mtu)
+        if ipv4_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv4_method,
+                address=ipv4_addr,
+                gateway=ipv4_gw,
+                version=4
+            )
+        if ipv6_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv6_method,
+                address=ipv6_addr,
+                gateway=ipv6_gw,
+                version=6
+            )
+
+        self._exec_command(command=command)
+
+    def add_dummy(
+            self,
+            con_name,
+            ifname,
+            auto_connect=False,
+            save=False,
+            ipv4_method=None,
+            ipv4_addr=None,
+            ipv4_gw=None,
+            ipv6_method=None,
+            ipv6_addr=None,
+            ipv6_gw=None
+    ):
+        """
+        Creates a dummy connection.
+
+        Args:
+            con_name (str): the created connection's name.
+            ifname (str): the interface name to use.
+            auto_connect (bool): True to connect automatically, or False for
+                manual.
+            save (bool): True to persist the connection, or False.
+            ipv4_method (str): setting method.
+                Available methods: auto, disabled, link-local, manual, shared.
+            ipv4_addr (str): a static address.
+            ipv4_gw (str): a gateway address.
+            ipv6_method (str): setting method.
+                Available methods: auto, dhcp, disabled, ignore, link-local,
+                manual, shared.
+            ipv6_addr (str): a static address.
+            ipv6_gw (str): a gateway address.
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
+        """
+        common_options = self._generate_common_options(
+            con_type="dummy",
+            con_name=con_name,
+            ifname=ifname,
+            auto_connect=auto_connect,
+            save=save
+        )
+
+        command = NMCLI_CONNECTION_ADD + " " + common_options
+
+        if ipv4_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv4_method,
+                address=ipv4_addr,
+                gateway=ipv4_gw,
+                version=4
+            )
+        if ipv6_method:
+            command += " " + self._generate_ip_options(
+                ip_method=ipv6_method,
+                address=ipv6_addr,
+                gateway=ipv6_gw,
+                version=6
+            )
+
+        self._exec_command(command=command)
+
+    def delete_connection(self, connection):
+        """
+        Deletes a connection.
+
+        Args:
+            connection (str): name, UUID or path.
+
+        Raises:
+            ConnectionDoesNotExistException: if a connection with the given
+            name does not exist.
+        """
+        if self.is_connection_exist(connection=connection):
+            self._exec_command(
+                command=NMCLI_CONNECTION_DELETE.format(id=connection)
+            )
+        raise ConnectionDoesNotExistException(connection)
+
+    @staticmethod
+    def _generate_common_options(
+            con_type,
+            con_name,
+            ifname,
+            auto_connect,
+            save
+    ):
+        """
+        Generates a string containing common options for the nmcli tool.
+
+        Args:
+            con_type (str): the connection type.
+            con_name (str): the created connection's name.
+            ifname (str): the interface name to use.
+            auto_connect (bool): True to connect automatically, or False for
+                manual.
+            save (bool): True to persist the connection, or False.
+
+        Returns:
+            str: a common options string.
+        """
+        return COMMON_OPTIONS.format(
+            type=con_type,
+            con_name=con_name,
+            ifname=ifname,
+            auto_connect="yes" if auto_connect else "no",
+            save="yes" if save else "no"
+        )
+
+    @staticmethod
+    def _generate_ip_options(ip_method, address, gateway, version):
+        """
+        Generates a string containing ip options for the nmcli tool.
+
+        Args:
+            ip_method (str): setting method.
+                Available methods: auto, disabled, link-local, manual, shared.
+            address (str): a static address.
+            gateway (str): a gateway address.
+            version (int): IP version.
+
+        Returns:
+            str: an ip options string.
+        """
+        ip_options = ""
+
+        if ip_method:
+            ip_options += (
+                IPV4_METHOD.format(method=ip_method) if version == 4
+                else IPV6_METHOD.format(method=ip_method)
+            )
+            if ip_method == IP_MANUAL_METHOD:
+                if address and gateway:
+                    ip_options += (
+                        IPV4_STATIC.format(
+                            address=address,
+                            gateway=gateway
+                        )
+                        if version == 4
+                        else IPV6_STATIC.format(
+                            address=address,
+                            gateway=gateway
+                        )
+                    )
+        return ip_options
+
+
+class ConnectionDoesNotExistException(Exception):
+    def __init__(self, con_name):
+        super(ConnectionDoesNotExistException, self).__init__(con_name)
+        self.con_name = con_name
+
+    def __str__(self):
+        return "connection {con} does not exist".format(con=self.con_name)

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -582,16 +582,16 @@ class NMCLI(Service):
         if mtu:
             command += " mtu {mtu}".format(mtu=mtu)
         if ipv4_addr:
-            if not self._is_ip_valid(ip_address=ipv4_addr):
+            if not self._get_ip_version(ip_address=ipv4_addr) == 4:
                 raise InvalidIPException(ip=ipv4_addr)
         if ipv4_gw:
-            if not self._is_ip_valid(ip_address=ipv4_gw):
+            if not self._get_ip_version(ip_address=ipv4_gw) == 4:
                 raise InvalidIPException(ip=ipv4_gw)
         if ipv6_addr:
-            if not self._is_ip_valid(ip_address=ipv6_addr):
+            if not self._get_ip_version(ip_address=ipv6_addr) == 6:
                 raise InvalidIPException(ip=ipv6_addr)
         if ipv6_gw:
-            if not self._is_ip_valid(ip_address=ipv6_gw):
+            if not self._get_ip_version(ip_address=ipv6_gw) == 6:
                 raise InvalidIPException(ip=ipv6_gw)
         if ipv4_method:
             command += " " + self._generate_ip_options(
@@ -710,7 +710,7 @@ class NMCLI(Service):
             return False
         return True
 
-    def get_ip_version(self, ip_address):
+    def _get_ip_version(self, ip_address):
         """
         Gets the IP version of an IP address.
 
@@ -726,7 +726,7 @@ class NMCLI(Service):
         """
         if self._is_ip_valid(ip_address=ip_address):
             return netaddr.IPAddress(addr=ip_address).version
-        raise InvalidIPException(ip_address)
+
 
 
 class ConnectionDoesNotExistException(Exception):
@@ -762,4 +762,4 @@ class InvalidMACException(Exception):
         self.mac = mac
 
     def __str__(self):
-        return "MAC address {addr} is in-valid".format(addr=self.mac)
+        return "MAC address {addr} is invalid".format(addr=self.mac)

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -96,7 +96,7 @@ class NMCLI(Service):
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
-            indicating a failure in execution.
+                indicating a failure in execution.
         """
         split = shlex.split(command)
 
@@ -127,7 +127,7 @@ class NMCLI(Service):
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
-            indicating a failure in execution.
+                indicating a failure in execution.
         """
         connections = []
 
@@ -160,6 +160,9 @@ class NMCLI(Service):
                     - "type"
                     - "mac"
                     - "mtu"
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+                indicating a failure in execution.
         """
         device_names = self._exec_command(
             command="nmcli -g {name} {obj} {operation}".format(
@@ -212,7 +215,7 @@ class NMCLI(Service):
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
-            indicating a failure in execution.
+                indicating a failure in execution.
         """
         self._exec_command(
             command="nmcli {obj} {state} {connection}".format(
@@ -327,7 +330,7 @@ class NMCLI(Service):
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
-            indicating a failure in execution.
+                indicating a failure in execution.
 
         Notes:
             The parameters [ipv4_addr, ipv4_gw, ipv6_addr, ipv6_gw] are to be
@@ -381,7 +384,7 @@ class NMCLI(Service):
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
-            indicating a failure in execution.
+                indicating a failure in execution.
         """
         type_options = {SlaveOptions.MASTER: master}
 
@@ -436,7 +439,7 @@ class NMCLI(Service):
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
-            indicating a failure in execution.
+                indicating a failure in execution.
         """
         type_options = {VlanOptions.DEV: dev, VlanOptions.ID: vlan_id}
         if mtu:
@@ -495,7 +498,7 @@ class NMCLI(Service):
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
-            indicating a failure in execution.
+                indicating a failure in execution.
         """
         self._exec_command(
             command=self._nmcli_cmd_builder(
@@ -550,8 +553,8 @@ class NMCLI(Service):
             connection (str): name, UUID or path.
 
         Raises:
-            ConnectionDoesNotExistException: if a connection with the given
-                name does not exist.
+            CommandExecutionFailure: if the remote host returned a code
+                indicating a failure in execution.
         """
         self._exec_command(
             command=self._nmcli_cmd_builder(
@@ -593,7 +596,7 @@ class NMCLI(Service):
         ipv4_addr, ipv4_gw, ipv4_method, ipv6_addr, ipv6_gw, ipv6_method
     ):
         """
-        Extends a connection adding command with optional parameters.
+        Extends an nmcli command with IP options.
 
         Args:
             ipv4_addr (str): a static address.
@@ -607,8 +610,7 @@ class NMCLI(Service):
                 manual, shared.
 
         Returns:
-            str: an nmcli connection add command with the passed in optional
-                parameters.
+            str: a substring of the nmcli command formatted with IP options.
         """
         command = ""
 
@@ -635,7 +637,7 @@ class NMCLI(Service):
         con_type, con_name, ifname, auto_connect=None, save=None
     ):
         """
-        Generates a string containing common options for the nmcli tool.
+        Generates a string containing common options for the nmcli command.
 
         Args:
             con_type (str): the connection type.

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -15,7 +15,6 @@ IPV6_STATIC = "ipv6.addresses {address} ipv6.gateway {gateway}"
 IPV4_METHOD = "ipv4.method {method}"
 IPV6_METHOD = "ipv6.method {method}"
 
-
 COMMON_OPTIONS = (
     "type {type}"
     "con-name {con_name} "

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -165,20 +165,26 @@ class NMCLI(Service):
                     - "mac"
                     - "mtu"
         """
-        devices = []
-        connections_names = [
-            connection.get(ConnectionDetails.NAME)
-            for connection in self.get_all_connections()
+        device_names = self._exec_command(
+            command="nmcli -g {name} {obj} {operation}".format(
+                name=NmGeneralSettings.DEVICE,
+                obj=Objects.DEVICE,
+                operation=Operations.SHOW,
+            )
+        )
+        device_names = [
+            name for name in device_names.splitlines() if name != ""
         ]
 
-        for name in connections_names:
+        devices = []
+
+        for name in device_names:
             out = self._exec_command(
                 command=(
                     "nmcli -e no "
-                    "-g {name},{type},{mac},{mtu} "
+                    "-g {type},{mac},{mtu} "
                     "{obj} {operation} {device}"
                 ).format(
-                    name=NmGeneralSettings.DEVICE,
                     type=NmGeneralSettings.TYPE,
                     mac=NmGeneralSettings.MAC,
                     mtu=NmGeneralSettings.MTU,
@@ -190,36 +196,14 @@ class NMCLI(Service):
             properties = out.splitlines()
             devices.append(
                 {
-                    DeviceDetails.NAME: properties[0],
-                    DeviceDetails.TYPE: properties[1],
-                    DeviceDetails.MAC: properties[2],
-                    DeviceDetails.MTU: properties[3],
+                    DeviceDetails.NAME: name,
+                    DeviceDetails.TYPE: properties[0],
+                    DeviceDetails.MAC: properties[1],
+                    DeviceDetails.MTU: properties[2],
                 }
             )
 
         return devices
-
-    def get_device(self, name):
-        """
-        Gets a device's details.
-
-        Args:
-            name (str): device name.
-
-        Returns:
-            dict: device details. contains the following keys:
-                - "name"
-                - "type"
-                - "mac"
-                - "mtu"
-        """
-        devices = self.get_all_devices()
-        device = [
-            device
-            for device in devices
-            if device.get(DeviceDetails.NAME) == name
-        ]
-        return device[0] if device else {}
 
     def set_connection_state(self, connection, state):
         """

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -31,9 +31,7 @@ DEFAULT_BOND_MODE = "active-backup"
 
 DEFAULT_MIIMON = 100
 
-ERROR_MSG_FORMAT = (
-    "command -> {command}\nRC -> {rc}\nOUT -> {out}\nERROR -> {err}"
-)
+ERROR_MSG_FORMAT = "command -> {command}\nRC -> {rc}\nOUT -> {out}\nERROR -> {err}"  # noqa: E501
 
 NMCLI_COMMAND = "nmcli {options} {object} {command}"
 
@@ -48,6 +46,7 @@ class NMCLI(Service):
     """
     This class implements network operations using nmcli.
     """
+
     def __init__(self, host):
         super(NMCLI, self).__init__(host)
         self._executor = host.executor()
@@ -72,17 +71,10 @@ class NMCLI(Service):
 
         if rc != 0:
             logger.error(
-                ERROR_MSG_FORMAT.format(
-                    command=command,
-                    rc=rc,
-                    out=out,
-                    err=err)
+                ERROR_MSG_FORMAT.format(command=command, rc=rc, out=out, err=err)  # noqa: E501
             )
             raise CommandExecutionFailure(
-                executor=self._executor,
-                cmd=split,
-                rc=rc,
-                err=err
+                executor=self._executor, cmd=split, rc=rc, err=err
             )
         return out
 
@@ -132,14 +124,11 @@ class NMCLI(Service):
             indicating a failure in execution.
         """
         command = NMCLI_COMMAND.format(
-            options="-m multiline",
-            object="connection",
-            command="show"
+            options="-m multiline", object="connection", command="show"
         )
         out = self._exec_command(command=command)
         con_names = [
-            line.strip("NAME:").strip() for line in out.splitlines()
-            if "NAME:" in line
+            line.strip("NAME:").strip() for line in out.splitlines() if "NAME:" in line  # noqa: E501
         ]
         return [self.get_connection_uuid(con_name=name) for name in con_names]
 
@@ -162,7 +151,7 @@ class NMCLI(Service):
                 command=NMCLI_COMMAND.format(
                     options="-g connection.uuid",
                     object="connection",
-                    command="show {con}".format(con=con_name)
+                    command="show {con}".format(con=con_name),
                 )
             ).strip()
         raise ConnectionDoesNotExistException(con_name)
@@ -185,7 +174,7 @@ class NMCLI(Service):
             command=NMCLI_COMMAND.format(
                 options="-g GENERAL.TYPE",
                 object="device",
-                command="show {device}".format(device=device)
+                command="show {device}".format(device=device),
             )
         ).strip()
 
@@ -202,29 +191,26 @@ class NMCLI(Service):
             ConnectionDoesNotExistException: if a connection with the given
             name does not exist.
         """
-        command = "nmcli connection {state} {con}".format(
-            state=state,
-            con=connection
-        )
+        command = "nmcli connection {state} {con}".format(state=state, con=connection)  # noqa: E501
         if self.is_connection_exist(connection=connection):
             self._exec_command(command=command)
         else:
             raise ConnectionDoesNotExistException(connection)
 
     def add_ethernet(
-            self,
-            con_name,
-            ifname,
-            auto_connect=False,
-            save=False,
-            mac=None,
-            mtu=None,
-            ipv4_method=None,
-            ipv4_addr=None,
-            ipv4_gw=None,
-            ipv6_method=None,
-            ipv6_addr=None,
-            ipv6_gw=None
+        self,
+        con_name,
+        ifname,
+        auto_connect=False,
+        save=False,
+        mac=None,
+        mtu=None,
+        ipv4_method=None,
+        ipv4_addr=None,
+        ipv4_gw=None,
+        ipv6_method=None,
+        ipv6_addr=None,
+        ipv6_gw=None,
     ):
         """
         Creates an ETHERNET connection.
@@ -258,7 +244,7 @@ class NMCLI(Service):
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
-            save=save
+            save=save,
         )
 
         command = NMCLI_CONNECTION_ADD + " " + common_options
@@ -275,25 +261,25 @@ class NMCLI(Service):
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
             ipv6_method=ipv6_method,
-            mtu=mtu
+            mtu=mtu,
         )
 
         self._exec_command(command=command)
 
     def add_bond(
-            self,
-            con_name,
-            ifname,
-            mode=DEFAULT_BOND_MODE,
-            miimon=DEFAULT_MIIMON,
-            auto_connect=False,
-            save=False,
-            ipv4_method=None,
-            ipv4_addr=None,
-            ipv4_gw=None,
-            ipv6_method=None,
-            ipv6_addr=None,
-            ipv6_gw=None
+        self,
+        con_name,
+        ifname,
+        mode=DEFAULT_BOND_MODE,
+        miimon=DEFAULT_MIIMON,
+        auto_connect=False,
+        save=False,
+        ipv4_method=None,
+        ipv4_addr=None,
+        ipv4_gw=None,
+        ipv6_method=None,
+        ipv6_addr=None,
+        ipv6_gw=None,
     ):
         """
         Creates a bond connection.
@@ -333,20 +319,12 @@ class NMCLI(Service):
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
-            save=save
+            save=save,
         )
 
-        type_options = "mode {mode} miimon {miimon}".format(
-            mode=mode, miimon=miimon
-        )
+        type_options = "mode {mode} miimon {miimon}".format(mode=mode, miimon=miimon)  # noqa: E501
 
-        command = (
-                NMCLI_CONNECTION_ADD
-                + " "
-                + common_options
-                + " "
-                + type_options
-        )
+        command = NMCLI_CONNECTION_ADD + " " + common_options + " " + type_options  # noqa: E501
 
         command += self._extend_add_command(
             ipv4_addr=ipv4_addr,
@@ -355,19 +333,12 @@ class NMCLI(Service):
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
             ipv6_method=ipv6_method,
-            mtu=0
+            mtu=0,
         )
 
         self._exec_command(command=command)
 
-    def add_slave(
-            self,
-            con_name,
-            ifname,
-            master,
-            auto_connect=False,
-            save=False
-    ):
+    def add_slave(self, con_name, ifname, master, auto_connect=False, save=False):  # noqa: E501
         """
         Creates a bond slave.
 
@@ -390,32 +361,32 @@ class NMCLI(Service):
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
-            save=save
+            save=save,
         )
 
         command = (
-                NMCLI_CONNECTION_ADD
-                + " "
-                + common_options
-                + " master {master}".format(master=master)
+            NMCLI_CONNECTION_ADD
+            + " "
+            + common_options
+            + " master {master}".format(master=master)
         )
 
         self._exec_command(command=command)
 
     def add_vlan(
-            self,
-            con_name,
-            dev,
-            vlan_id,
-            auto_connect=False,
-            save=False,
-            mtu=None,
-            ipv4_method=None,
-            ipv4_addr=None,
-            ipv4_gw=None,
-            ipv6_method=None,
-            ipv6_addr=None,
-            ipv6_gw=None
+        self,
+        con_name,
+        dev,
+        vlan_id,
+        auto_connect=False,
+        save=False,
+        mtu=None,
+        ipv4_method=None,
+        ipv4_addr=None,
+        ipv4_gw=None,
+        ipv6_method=None,
+        ipv6_addr=None,
+        ipv6_gw=None,
     ):
         """
         Creates a VLAN connection.
@@ -450,15 +421,15 @@ class NMCLI(Service):
             con_name=con_name,
             ifname=dev,
             auto_connect=auto_connect,
-            save=save
+            save=save,
         )
 
         command = (
-                NMCLI_CONNECTION_ADD
-                + " "
-                + common_options
-                + " dev {dev}".format(dev=dev)
-                + " id {id}".format(id=vlan_id)
+            NMCLI_CONNECTION_ADD
+            + " "
+            + common_options
+            + " dev {dev}".format(dev=dev)
+            + " id {id}".format(id=vlan_id)
         )
 
         command += self._extend_add_command(
@@ -468,23 +439,23 @@ class NMCLI(Service):
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
             ipv6_method=ipv6_method,
-            mtu=mtu
+            mtu=mtu,
         )
 
         self._exec_command(command=command)
 
     def add_dummy(
-            self,
-            con_name,
-            ifname,
-            auto_connect=False,
-            save=False,
-            ipv4_method=None,
-            ipv4_addr=None,
-            ipv4_gw=None,
-            ipv6_method=None,
-            ipv6_addr=None,
-            ipv6_gw=None
+        self,
+        con_name,
+        ifname,
+        auto_connect=False,
+        save=False,
+        ipv4_method=None,
+        ipv4_addr=None,
+        ipv4_gw=None,
+        ipv6_method=None,
+        ipv6_addr=None,
+        ipv6_gw=None,
     ):
         """
         Creates a dummy connection.
@@ -514,7 +485,7 @@ class NMCLI(Service):
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
-            save=save
+            save=save,
         )
 
         command = NMCLI_CONNECTION_ADD + " " + common_options
@@ -526,7 +497,7 @@ class NMCLI(Service):
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
             ipv6_method=ipv6_method,
-            mtu=0
+            mtu=0,
         )
 
         self._exec_command(command=command)
@@ -573,21 +544,12 @@ class NMCLI(Service):
                 name does not exist.
         """
         if self.is_connection_exist(connection=connection):
-            self._exec_command(
-                command=NMCLI_CONNECTION_DELETE.format(id=connection)
-            )
+            self._exec_command(command=NMCLI_CONNECTION_DELETE.format(id=connection))  # noqa: E501
         else:
             raise ConnectionDoesNotExistException(connection)
 
     def _extend_add_command(
-        self,
-        ipv4_addr,
-        ipv4_gw,
-        ipv4_method,
-        ipv6_addr,
-        ipv6_gw,
-        ipv6_method,
-        mtu
+        self, ipv4_addr, ipv4_gw, ipv4_method, ipv6_addr, ipv6_gw, ipv6_method, mtu  # noqa: E501
     ):
         """
         Extends a connection adding command with optional parameters.
@@ -625,28 +587,16 @@ class NMCLI(Service):
                 raise InvalidIPException(ip=ipv6_gw)
         if ipv4_method:
             command += " " + self._generate_ip_options(
-                ip_method=ipv4_method,
-                address=ipv4_addr,
-                gateway=ipv4_gw,
-                version=4
+                ip_method=ipv4_method, address=ipv4_addr, gateway=ipv4_gw, version=4  # noqa: E501
             )
         if ipv6_method:
             command += " " + self._generate_ip_options(
-                ip_method=ipv6_method,
-                address=ipv6_addr,
-                gateway=ipv6_gw,
-                version=6
+                ip_method=ipv6_method, address=ipv6_addr, gateway=ipv6_gw, version=6  # noqa: E501
             )
         return command
 
     @staticmethod
-    def _generate_common_options(
-            con_type,
-            con_name,
-            ifname,
-            auto_connect,
-            save
-    ):
+    def _generate_common_options(con_type, con_name, ifname, auto_connect, save):  # noqa: E501
         """
         Generates a string containing common options for the nmcli tool.
 
@@ -666,7 +616,7 @@ class NMCLI(Service):
             con_name=con_name,
             ifname=ifname,
             auto_connect="yes" if auto_connect else "no",
-            save="yes" if save else "no"
+            save="yes" if save else "no",
         )
 
     @staticmethod
@@ -688,21 +638,16 @@ class NMCLI(Service):
 
         if ip_method:
             ip_options += (
-                IPV4_METHOD.format(method=ip_method) if version == 4
+                IPV4_METHOD.format(method=ip_method)
+                if version == 4
                 else IPV6_METHOD.format(method=ip_method)
             )
             if ip_method == IP_MANUAL_METHOD:
                 if address and gateway:
                     ip_options += " " + (
-                        IPV4_STATIC.format(
-                            address=address,
-                            gateway=gateway
-                        )
+                        IPV4_STATIC.format(address=address, gateway=gateway)
                         if version == 4
-                        else IPV6_STATIC.format(
-                            address=address,
-                            gateway=gateway
-                        )
+                        else IPV6_STATIC.format(address=address, gateway=gateway)  # noqa: E501
                     )
         return ip_options
 
@@ -756,7 +701,6 @@ class NMCLI(Service):
         """
         if self._is_ip_valid(ip_address=ip_address):
             return netaddr.IPAddress(addr=ip_address).version
-
 
 
 class ConnectionDoesNotExistException(Exception):

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -12,9 +12,8 @@ from rrmngmnt.service import Service
 IPV4_STATIC = "ipv4.addresses {address} ipv4.gateway {gateway}"
 IPV6_STATIC = "ipv6.addresses {address} ipv6.gateway {gateway}"
 
-_IP_METHOD = "ipv{version}.method {method}"
-IPV4_METHOD = _IP_METHOD.format(version=4)
-IPV6_METHOD = _IP_METHOD.format(version=6)
+IPV4_METHOD = "ipv4.method {method}"
+IPV6_METHOD = "ipv6.method {method}"
 
 COMMON_OPTIONS = (
     "type {type}"
@@ -35,8 +34,7 @@ ERROR_MSG_FORMAT = (
 )
 
 NMCLI_COMMAND = "nmcli {options} {object} {command}"
-NMCLI_CONNECTION = "nmcli connection"
-NMCLI_CONNECTION_DELETE = NMCLI_CONNECTION + " delete {id}"
+NMCLI_CONNECTION_DELETE = "nmcli connection delete {id}"
 NMCLI_CONNECTION_ADD = "nmcli connection add"
 
 logger = logging.getLogger(__name__)

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -5,30 +5,8 @@ NetworkManager.
 """
 import shlex
 
-import netaddr
-
-from rrmngmnt.errors import CommandExecutionFailure, GeneralResourceError
+from rrmngmnt.errors import CommandExecutionFailure
 from rrmngmnt.service import Service
-
-IPV4_STATIC = "ipv4.addresses {address} ipv4.gateway {gateway}"
-IPV6_STATIC = "ipv6.addresses {address} ipv6.gateway {gateway}"
-
-IPV4_METHOD = "ipv4.method {method}"
-IPV6_METHOD = "ipv6.method {method}"
-
-COMMON_OPTIONS = (
-    "type {type} "
-    "con-name {con_name} "
-    "ifname {ifname} "
-    "autoconnect {auto_connect} "
-    "save {save}"
-)
-
-IP_MANUAL_METHOD = "manual"
-
-DEFAULT_BOND_MODE = "active-backup"
-
-DEFAULT_MIIMON = 100
 
 ERROR_MSG_FORMAT = "command -> {command}\nRC -> {rc}\nOUT -> {out}\nERROR -> {err}"  # noqa: E501
 
@@ -75,83 +53,72 @@ class NMCLI(Service):
             )
         return out
 
-    def is_connection_exist(self, connection):
+    def get_all_connections(self):
         """
-        Checks if a connection exists.
-
-        Args:
-            connection (str):  name, UUID or path.
+        Gets existing NetworkManager profiles details.
 
         Returns:
-            bool: True if the connection exists, or False if it does not.
-        """
-        command = "nmcli connection show {con}".format(con=connection)
-        try:
-            self._exec_command(command=command)
-        except CommandExecutionFailure:
-            return False
-        return True
-
-    def is_device_exist(self, device):
-        """
-        Checks if a device exists.
-
-        Args:
-            device (str): device name.
-
-        Returns:
-            bool: True if the device exists, or False if it does not.
-        """
-        command = "nmcli device show {dev}".format(dev=device)
-        try:
-            self._exec_command(command=command)
-        except CommandExecutionFailure:
-            return False
-        return True
-
-    def get_all_connections_uuids(self):
-        """
-        Gets existing NetworkManager profiles UUIDs.
-
-        Returns:
-            list[str]: all connection UUIDs.
+            list[dict]: each dict in the returned list represents a profile,
+                and has the following keys:
+                    - "name"
+                    - "uuid"
+                    - "type"
+                    - "device"
 
         Raises:
             CommandExecutionFailure: if the remote host returned a code
             indicating a failure in execution.
         """
-        command = NMCLI_COMMAND.format(
-            options="-m multiline", object="connection", command="show"
-        )
-        out = self._exec_command(command=command)
-        con_names = [
-            line.strip("NAME:").strip() for line in out.splitlines() if "NAME:" in line  # noqa: E501
-        ]
-        return [self.get_connection_uuid(con_name=name) for name in con_names]
+        cons = list()
 
-    def get_connection_uuid(self, con_name):
+        out = self._exec_command(command="nmcli -t con show")
+        for line in out.splitlines():
+            properties = line.split(":")
+            cons.append(
+                {
+                    "name": properties[0],
+                    "uuid": properties[1],
+                    "type": properties[2],
+                    "device": properties[3],
+                }
+            )
+
+        return cons
+
+    def get_all_devices(self):
         """
-        Gets a connection's UUID by the connection's name.
-
-        Args:
-            con_name (str): the connection's name.
+        Gets existing devices details.
 
         Returns:
-            str: the connection's UUID.
-
-        Raises:
-            ConnectionDoesNotExistException: if a connection with the given
-            name does not exist.
+            list[dict]: each dict in the returned list represents a device,
+                and has the following keys:
+                    - "name"
+                    - "type"
+                    - "mac"
+                    - "mtu"
         """
-        if self.is_connection_exist(connection=con_name):
-            return self._exec_command(
-                command=NMCLI_COMMAND.format(
-                    options="-g connection.uuid",
-                    object="connection",
-                    command="show {con}".format(con=con_name),
-                )
-            ).strip()
-        raise ConnectionDoesNotExistException(con_name)
+        devices = list()
+        con_names = [con.get("name") for con in self.get_all_connections()]
+
+        for name in con_names:
+            out = self._exec_command(
+                command=(
+                    "nmcli -e no "
+                    "-g GENERAL.DEVICE,GENERAL.TYPE,GENERAL.HWADDR,GENERAL.MTU "  # noqa: E501
+                    "dev show {con}"
+                ).format(con=name)
+            )
+            properties = out.splitlines()
+            devices.append(
+                {
+                    "name": properties[0],
+                    "type": properties[1],
+                    "mac": properties[2],
+                    "mtu": properties[3],
+                }
+            )
+
+        return devices
 
     def get_device_type(self, device):
         """
@@ -168,11 +135,7 @@ class NMCLI(Service):
             indicating a failure in execution.
         """
         return self._exec_command(
-            command=NMCLI_COMMAND.format(
-                options="-g GENERAL.TYPE",
-                object="device",
-                command="show {device}".format(device=device),
-            )
+            command="nmcli -g GENERAL.TYPE device show {dev}".format(dev=device)  # noqa: E501
         ).strip()
 
     def set_connection_state(self, connection, state):
@@ -185,21 +148,19 @@ class NMCLI(Service):
                 available states are: ["up", "down"].
 
         Raises:
-            ConnectionDoesNotExistException: if a connection with the given
-            name does not exist.
+            CommandExecutionFailure: if the remote host returned a code
+            indicating a failure in execution.
         """
-        command = "nmcli connection {state} {con}".format(state=state, con=connection)  # noqa: E501
-        if self.is_connection_exist(connection=connection):
-            self._exec_command(command=command)
-        else:
-            raise ConnectionDoesNotExistException(connection)
+        self._exec_command(
+            command="nmcli connection {state} {con}".format(state=state, con=connection)  # noqa: E501
+        )
 
-    def add_ethernet(
+    def add_ethernet_connection(
         self,
         con_name,
         ifname,
-        auto_connect=False,
-        save=False,
+        auto_connect=None,
+        save=None,
         mac=None,
         mtu=None,
         ipv4_method=None,
@@ -233,32 +194,27 @@ class NMCLI(Service):
         Raises:
             CommandExecutionFailure: if the remote host returned a code
                 indicating a failure in execution.
-            InvalidMACException: if an invalid MAC address was passed.
-            InvalidIPException: if an invalid IP address was passed.
         """
-        common_options = self._generate_common_options(
+        type_options = {}
+        if mac:
+            type_options["mac"] = mac
+        if mtu:
+            type_options["mtu"] = mtu
+
+        command = self._nmcli_con_cmd_builder(
+            operation="add",
             con_type="ethernet",
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
             save=save,
-        )
-
-        command = NMCLI_CONNECTION_ADD + " " + common_options
-
-        if mac:
-            if not self._is_mac_valid(mac_address=mac):
-                raise InvalidMACException(mac=mac)
-            command += " mac {mac}".format(mac=mac)
-
-        command += self._extend_add_command(
+            ipv4_method=ipv4_method,
             ipv4_addr=ipv4_addr,
             ipv4_gw=ipv4_gw,
-            ipv4_method=ipv4_method,
+            ipv6_method=ipv6_method,
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
-            ipv6_method=ipv6_method,
-            mtu=mtu,
+            type_options=type_options,
         )
 
         self._exec_command(command=command)
@@ -267,10 +223,10 @@ class NMCLI(Service):
         self,
         con_name,
         ifname,
-        mode=DEFAULT_BOND_MODE,
-        miimon=DEFAULT_MIIMON,
-        auto_connect=False,
-        save=False,
+        mode=None,
+        miimon=None,
+        auto_connect=None,
+        save=None,
         ipv4_method=None,
         ipv4_addr=None,
         ipv4_gw=None,
@@ -311,31 +267,31 @@ class NMCLI(Service):
             The parameters [ipv4_addr, ipv4_gw, ipv6_addr, ipv6_gw] are to be
             used with a 'manual' IP method respectively.
         """
-        common_options = self._generate_common_options(
+        type_options = {}
+        if mode:
+            type_options["mode"] = mode
+        if miimon:
+            type_options["miimon"] = miimon
+
+        command = self._nmcli_con_cmd_builder(
+            operation="add",
             con_type="bond",
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
             save=save,
-        )
-
-        type_options = "mode {mode} miimon {miimon}".format(mode=mode, miimon=miimon)  # noqa: E501
-
-        command = NMCLI_CONNECTION_ADD + " " + common_options + " " + type_options  # noqa: E501
-
-        command += self._extend_add_command(
+            ipv4_method=ipv4_method,
             ipv4_addr=ipv4_addr,
             ipv4_gw=ipv4_gw,
-            ipv4_method=ipv4_method,
+            ipv6_method=ipv6_method,
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
-            ipv6_method=ipv6_method,
-            mtu=0,
+            type_options=type_options,
         )
 
         self._exec_command(command=command)
 
-    def add_slave(self, con_name, ifname, master, auto_connect=False, save=False):  # noqa: E501
+    def add_slave(self, con_name, ifname, master, auto_connect=None, save=None):  # noqa: E501
         """
         Creates a bond slave.
 
@@ -352,20 +308,16 @@ class NMCLI(Service):
             indicating a failure in execution.
         """
         slave_type = self.get_device_type(device=ifname)
+        type_options = {"master": master}
 
-        common_options = self._generate_common_options(
+        command = self._nmcli_con_cmd_builder(
+            operation="add",
             con_type=slave_type,
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
             save=save,
-        )
-
-        command = (
-            NMCLI_CONNECTION_ADD
-            + " "
-            + common_options
-            + " master {master}".format(master=master)
+            type_options=type_options,
         )
 
         self._exec_command(command=command)
@@ -375,9 +327,9 @@ class NMCLI(Service):
         con_name,
         dev,
         vlan_id,
-        auto_connect=False,
-        save=False,
         mtu=None,
+        auto_connect=None,
+        save=None,
         ipv4_method=None,
         ipv4_addr=None,
         ipv4_gw=None,
@@ -392,10 +344,10 @@ class NMCLI(Service):
             con_name (str): the created connection's name.
             dev (str): parent device.
             vlan_id (int): VLAN ID.
+            mtu (int): MTU to set for the connection.
             auto_connect (bool): True to connect automatically, or False for
                 manual.
             save (bool): True to persist the connection, or False.
-            mtu (int): MTU to set for the connection.
             ipv4_method (str): setting method.
                 Available methods: auto, disabled, link-local, manual, shared.
             ipv4_addr (str): a static address.
@@ -410,33 +362,24 @@ class NMCLI(Service):
             CommandExecutionFailure: if the remote host returned a code
             indicating a failure in execution.
         """
-        if not self.is_device_exist(device=dev):
-            raise DeviceDoesNotExistException(dev)
+        type_options = {"dev": dev, "id": vlan_id}
+        if mtu:
+            type_options["mtu"] = mtu
 
-        common_options = self._generate_common_options(
+        command = self._nmcli_con_cmd_builder(
+            operation="add",
             con_type="vlan",
             con_name=con_name,
             ifname=dev,
             auto_connect=auto_connect,
             save=save,
-        )
-
-        command = (
-            NMCLI_CONNECTION_ADD
-            + " "
-            + common_options
-            + " dev {dev}".format(dev=dev)
-            + " id {id}".format(id=vlan_id)
-        )
-
-        command += self._extend_add_command(
+            ipv4_method=ipv4_method,
             ipv4_addr=ipv4_addr,
             ipv4_gw=ipv4_gw,
-            ipv4_method=ipv4_method,
+            ipv6_method=ipv6_method,
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
-            ipv6_method=ipv6_method,
-            mtu=mtu,
+            type_options=type_options,
         )
 
         self._exec_command(command=command)
@@ -445,8 +388,8 @@ class NMCLI(Service):
         self,
         con_name,
         ifname,
-        auto_connect=False,
-        save=False,
+        auto_connect=None,
+        save=None,
         ipv4_method=None,
         ipv4_addr=None,
         ipv4_gw=None,
@@ -477,24 +420,19 @@ class NMCLI(Service):
             CommandExecutionFailure: if the remote host returned a code
             indicating a failure in execution.
         """
-        common_options = self._generate_common_options(
+        command = self._nmcli_con_cmd_builder(
+            operation="add",
             con_type="dummy",
             con_name=con_name,
             ifname=ifname,
             auto_connect=auto_connect,
             save=save,
-        )
-
-        command = NMCLI_CONNECTION_ADD + " " + common_options
-
-        command += self._extend_add_command(
+            ipv4_method=ipv4_method,
             ipv4_addr=ipv4_addr,
             ipv4_gw=ipv4_gw,
-            ipv4_method=ipv4_method,
+            ipv6_method=ipv6_method,
             ipv6_addr=ipv6_addr,
             ipv6_gw=ipv6_gw,
-            ipv6_method=ipv6_method,
-            mtu=0,
         )
 
         self._exec_command(command=command)
@@ -508,8 +446,6 @@ class NMCLI(Service):
             properties (dict): properties mapping to values
 
         Raises:
-            ConnectionDoesNotExistException: if a connection with the given
-                name does not exist.
             CommandExecutionFailure: if the remote host returned a code
                 indicating a failure in execution.
 
@@ -519,13 +455,9 @@ class NMCLI(Service):
             {"+ipv4.addresses": "192.168.23.2"}, or a '-' in order to remove
             a property.
         """
-        if not self.is_connection_exist(connection=connection):
-            raise ConnectionDoesNotExistException(connection)
-
-        command = "nmcli connection modify {con}".format(con=connection)
-
-        for prop, val in properties.items():
-            command += " " + prop + " " + val
+        command = self._nmcli_con_cmd_builder(
+            operation="modify", con_name=connection, type_options=properties
+        )
 
         self._exec_command(command=command)
 
@@ -540,13 +472,38 @@ class NMCLI(Service):
             ConnectionDoesNotExistException: if a connection with the given
                 name does not exist.
         """
-        if self.is_connection_exist(connection=connection):
-            self._exec_command(command=NMCLI_CONNECTION_DELETE.format(id=connection))  # noqa: E501
-        else:
-            raise ConnectionDoesNotExistException(connection)
+        command = self._nmcli_con_cmd_builder(operation="delete", con_name=connection)  # noqa: E501
 
-    def _extend_add_command(
-        self, ipv4_addr, ipv4_gw, ipv4_method, ipv6_addr, ipv6_gw, ipv6_method, mtu  # noqa: E501
+        self._exec_command(command=command)
+
+    def modify_device(self, device, properties):
+        """
+        Modifies a connection.
+
+        Args:
+            device (str): device name.
+            properties (dict): properties mapping to values
+
+        Raises:
+            CommandExecutionFailure: if the remote host returned a code
+                indicating a failure in execution.
+
+        Notes:
+            For multi-value properties e.g: ipv4.addresses, it is possible to
+            pass a property key with a '+' prefix to append a value e.g:
+            {"+ipv4.addresses": "192.168.23.2"}, or a '-' in order to remove
+            a property.
+        """
+        command = "nmcli dev modify {device}".format(device=device)
+
+        for k, v in properties.items():
+            command += " {k} {v}".format(k=k, v=v)
+
+        self._exec_command(command=command)
+
+    @staticmethod
+    def _ip_options_builder(
+        ipv4_addr, ipv4_gw, ipv4_method, ipv6_addr, ipv6_gw, ipv6_method
     ):
         """
         Extends a connection adding command with optional parameters.
@@ -561,39 +518,31 @@ class NMCLI(Service):
             ipv6_method (str): setting method.
                 Available methods: auto, dhcp, disabled, ignore, link-local,
                 manual, shared.
-            mtu (int): MTU to set for the connection.
 
         Returns:
             str: an nmcli connection add command with the passed in optional
                 parameters.
         """
         command = ""
-        if mtu:
-            command += " mtu {mtu}".format(mtu=mtu)
-        if ipv4_addr:
-            if not self._get_ip_version(ip_address=ipv4_addr) == 4:
-                raise InvalidIPException(ip=ipv4_addr)
-        if ipv4_gw:
-            if not self._get_ip_version(ip_address=ipv4_gw) == 4:
-                raise InvalidIPException(ip=ipv4_gw)
-        if ipv6_addr:
-            if not self._get_ip_version(ip_address=ipv6_addr) == 6:
-                raise InvalidIPException(ip=ipv6_addr)
-        if ipv6_gw:
-            if not self._get_ip_version(ip_address=ipv6_gw) == 6:
-                raise InvalidIPException(ip=ipv6_gw)
+
         if ipv4_method:
-            command += " " + self._generate_ip_options(
-                ip_method=ipv4_method, address=ipv4_addr, gateway=ipv4_gw, version=4  # noqa: E501
-            )
+            command += " ipv4.method {method}".format(method=ipv4_method)
         if ipv6_method:
-            command += " " + self._generate_ip_options(
-                ip_method=ipv6_method, address=ipv6_addr, gateway=ipv6_gw, version=6  # noqa: E501
-            )
+            command += " ipv6.method {method}".format(method=ipv6_method)
+        if ipv4_addr:
+            command += " ipv4.addresses {ipv4_addr}".format(ipv4_addr=ipv4_addr)  # noqa: E501
+        if ipv4_gw:
+            command += " ipv4.gateway {ipv4_gw}".format(ipv4_gw=ipv4_gw)
+        if ipv6_addr:
+            command += " ipv6.addresses {ipv6_addr}".format(ipv6_addr=ipv6_addr)  # noqa: E501
+        if ipv6_gw:
+            command += " ipv6.gateway {ipv6_gw}".format(ipv6_gw=ipv6_gw)
         return command
 
     @staticmethod
-    def _generate_common_options(con_type, con_name, ifname, auto_connect, save):  # noqa: E501
+    def _common_options_builder(
+        con_type, con_name, ifname, auto_connect=None, save=None
+    ):
         """
         Generates a string containing common options for the nmcli tool.
 
@@ -608,129 +557,92 @@ class NMCLI(Service):
         Returns:
             str: a common options string.
         """
-        return COMMON_OPTIONS.format(
-            type=con_type,
-            con_name=con_name,
-            ifname=ifname,
-            auto_connect="yes" if auto_connect else "no",
-            save="yes" if save else "no",
-        )
-
-    @staticmethod
-    def _generate_ip_options(ip_method, address, gateway, version):
-        """
-        Generates a string containing ip options for the nmcli tool.
-
-        Args:
-            ip_method (str): setting method.
-                Available methods: auto, disabled, link-local, manual, shared.
-            address (str): a static address.
-            gateway (str): a gateway address.
-            version (int): IP version.
-
-        Returns:
-            str: an ip options string.
-        """
-        ip_options = ""
-
-        if ip_method:
-            ip_options += (
-                IPV4_METHOD.format(method=ip_method)
-                if version == 4
-                else IPV6_METHOD.format(method=ip_method)
+        common_options = (
+            "type {type} " "con-name {con_name} " "ifname {ifname} "
+        ).format(type=con_type, con_name=con_name, ifname=ifname)
+        if auto_connect is not None:
+            common_options += "autoconnect {val}".format(
+                val="yes" if auto_connect is True else "no"
             )
-            if ip_method == IP_MANUAL_METHOD:
-                if address and gateway:
-                    ip_options += " " + (
-                        IPV4_STATIC.format(address=address, gateway=gateway)
-                        if version == 4
-                        else IPV6_STATIC.format(address=address, gateway=gateway)  # noqa: E501
-                    )
-        return ip_options
+        if save is not None:
+            common_options += "save {val}".format(val="yes" if save is True else "no")  # noqa: E501
 
-    @staticmethod
-    def _is_mac_valid(mac_address):
+        return common_options
+
+    def _nmcli_con_cmd_builder(
+        self,
+        operation,
+        con_name,
+        con_type=None,
+        ifname=None,
+        auto_connect=None,
+        save=None,
+        ipv4_method=None,
+        ipv4_addr=None,
+        ipv4_gw=None,
+        ipv6_method=None,
+        ipv6_addr=None,
+        ipv6_gw=None,
+        type_options=None,
+    ):
         """
-        Checks if a given MAC address is valid.
+        Builds an nmcli command.
 
         Args:
-            mac_address (str): MAC address.
+            operation (str): the operation to perform. e.g: "add", "delete" ...
+            con_name (str): the created connection's name.
+            con_type (str): the connection type. e.g: "ethernet", "bond" ...
+            ifname (str): the interface name to use.
+            auto_connect (bool): True to connect automatically, or False for
+                manual.
+            save (bool): True to persist the connection, or False.
+            ipv4_method (str): setting method.
+                Available methods: auto, disabled, link-local, manual, shared.
+            ipv4_addr (str): a static address.
+            ipv4_gw (str): a gateway address.
+            ipv6_method (str): setting method.
+                Available methods: auto, dhcp, disabled, ignore, link-local,
+                manual, shared.
+            ipv6_addr (str): a static address.
+            ipv6_gw (str): a gateway address.
+            type_options (dict): type specific options. e.g: {"mtu": "1500"}.
 
         Returns:
-            bool: True if the MAC address is valid, or False if not.
+            str: an nmcli command.
         """
-        try:
-            netaddr.EUI(addr=mac_address)
-        except netaddr.AddrFormatError:
-            return False
-        return True
+        command = "nmcli con {operation}".format(operation=operation, con=con_name)  # noqa: E501
 
-    @staticmethod
-    def _is_ip_valid(ip_address):
-        """
-        Checks if a given IP address is valid.
+        if operation == "delete":
+            command += " {con}".format(con=con_name)
 
-        Args:
-            ip_address (str): IP address.
+        elif operation == "modify":
+            command += " {con}".format(con=con_name)
+            if type_options:
+                for k, v in type_options.items():
+                    command += " {k} {v}".format(k=k, v=v)
 
-        Returns:
-            bool: True if the MAC address is valid, or False if not.
-        """
-        try:
-            netaddr.IPAddress(addr=ip_address)
-        except netaddr.AddrFormatError:
-            return False
-        return True
+        elif operation == "add":
+            command += " {common}".format(
+                common=self._common_options_builder(
+                    con_type=con_type,
+                    con_name=con_name,
+                    ifname=ifname,
+                    auto_connect=auto_connect,
+                    save=save,
+                )
+            )
 
-    def _get_ip_version(self, ip_address):
-        """
-        Gets the IP version of an IP address.
+            if type_options:
+                for k, v in type_options.items():
+                    command += " {k} {v}".format(k=k, v=v)
 
-        Args:
-            ip_address (str): IP address.
+            command += self._ip_options_builder(
+                ipv4_addr=ipv4_addr,
+                ipv4_gw=ipv4_gw,
+                ipv4_method=ipv4_method,
+                ipv6_addr=ipv6_addr,
+                ipv6_gw=ipv6_gw,
+                ipv6_method=ipv6_method,
+            )
 
-        Returns:
-            int: the IP version.
-
-        Raises:
-            InvalidIPException: if the ip_address parameter does not represent
-                a valid IP address.
-        """
-        if self._is_ip_valid(ip_address=ip_address):
-            return netaddr.IPAddress(addr=ip_address).version
-
-
-class ConnectionDoesNotExistException(GeneralResourceError):
-    def __init__(self, con_name):
-        super(ConnectionDoesNotExistException, self).__init__(con_name)
-        self.con_name = con_name
-
-    def __str__(self):
-        return "connection {con} does not exist".format(con=self.con_name)
-
-
-class DeviceDoesNotExistException(GeneralResourceError):
-    def __init__(self, device):
-        super(DeviceDoesNotExistException, self).__init__(device)
-        self.device = device
-
-    def __str__(self):
-        return "device {dev} does not exist".format(dev=self.device)
-
-
-class InvalidIPException(GeneralResourceError):
-    def __init__(self, ip):
-        super(InvalidIPException, self).__init__(ip)
-        self.ip = ip
-
-    def __str__(self):
-        return "IP address {addr} is in-valid".format(addr=self.ip)
-
-
-class InvalidMACException(GeneralResourceError):
-    def __init__(self, mac):
-        super(InvalidMACException, self).__init__(mac)
-        self.mac = mac
-
-    def __str__(self):
-        return "MAC address {addr} is invalid".format(addr=self.mac)
+        return command

--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -15,6 +15,7 @@ IPV6_STATIC = "ipv6.addresses {address} ipv6.gateway {gateway}"
 IPV4_METHOD = "ipv4.method {method}"
 IPV6_METHOD = "ipv6.method {method}"
 
+
 COMMON_OPTIONS = (
     "type {type}"
     "con-name {con_name} "
@@ -34,7 +35,9 @@ ERROR_MSG_FORMAT = (
 )
 
 NMCLI_COMMAND = "nmcli {options} {object} {command}"
+
 NMCLI_CONNECTION_DELETE = "nmcli connection delete {id}"
+
 NMCLI_CONNECTION_ADD = "nmcli connection add"
 
 logger = logging.getLogger(__name__)

--- a/rrmngmnt/ssh.py
+++ b/rrmngmnt/ssh.py
@@ -14,6 +14,7 @@ ID_RSA_PUB = os.path.join("%s", ".ssh/id_rsa.pub")
 ID_RSA_PRV = os.path.join("%s", ".ssh/id_rsa")
 CONNECTIVITY_TIMEOUT = 600
 CONNECTIVITY_SAMPLE_TIME = 20
+TCP_CONNECTION_TIMEOUT = 20
 
 
 class RemoteExecutor(Executor):
@@ -266,7 +267,8 @@ class RemoteExecutor(Executor):
     def wait_for_connectivity_state(
         self, positive,
         timeout=CONNECTIVITY_TIMEOUT,
-        sample_time=CONNECTIVITY_SAMPLE_TIME
+        sample_time=CONNECTIVITY_SAMPLE_TIME,
+        tcp_connection_timeout=TCP_CONNECTION_TIMEOUT
     ):
         """
         Wait until address will be connective or not via ssh
@@ -275,6 +277,7 @@ class RemoteExecutor(Executor):
             positive (bool): Wait for the positive or negative connective state
             timeout (int): Wait timeout
             sample_time (int): Sample the ssh each sample_time seconds
+            tcp_connection_timeout (int): TCP connection timeout
 
         Returns:
             bool: True, if positive and ssh is connective or negative and ssh
@@ -282,7 +285,9 @@ class RemoteExecutor(Executor):
         """
         reachable = "unreachable" if positive else "reachable"
         timeout_counter = 0
-        while self.is_connective() != positive:
+        while self.is_connective(
+            tcp_timeout=tcp_connection_timeout
+        ) != positive:
             if timeout_counter > timeout:
                 self.logger.error(
                     "Address %s is still %s via ssh, after %s seconds",

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -20,6 +20,7 @@ def provisioned_hosts(docker_ip, docker_services):
     return hosts
 
 
+@pytest.mark.skip(msg="Not enough tests in module to justify running")
 def test_echo(provisioned_hosts):
     ubuntu_host = provisioned_hosts['ubuntu']
     ubuntu_host.executor().run_cmd(['echo', 'hello'])

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -6,8 +6,10 @@ import pytest
 
 from rrmngmnt import Host, RootUser
 from rrmngmnt.errors import CommandExecutionFailure
-from rrmngmnt.nmcli import ConnectionDoesNotExistException, \
+from rrmngmnt.nmcli import (
+    ConnectionDoesNotExistException,
     DeviceDoesNotExistException
+)
 from tests.common import FakeExecutorFactory
 
 MOCK_ROOT_PASSWORD = "11111"

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -847,6 +847,11 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         (
             "nmcli con add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
+            "mtu 1600 id 163 dev enp8s0f0"
+        ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 id 163 mtu 1600"
         ): (0, "", ""),
         (

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -859,6 +859,11 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "mtu 1600 dev enp8s0f0 id 163"
         ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "id 163 mtu 1600 dev enp8s0f0"
+        ): (0, "", ""),
         "nmcli device show enp8s0f0": (0, "ethernet", ""),
         "nmcli device show enp8s0f00": (
             10,

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -52,6 +52,20 @@ class TestNmcliSanity(NmcliBase):
     """
 
     data = {
+        "nmcli -t connection show": (
+            0,
+            "\n".join(
+                [
+                    "virbr0:ba7aafc8-438e-4f8d-9f6e-3991fecebac0:bridge:virbr0",
+                    "enp1s0f1:702b48ac-750f-4856-8124-c8c55d8e3dda:802-3-ethernet:",
+                    "enp2s0f0:d2ee2c05-b28f-4529-8f42-ea4dbb17f308:802-3-ethernet:",
+                    "enp2s0f1:98e5c49f-bd72-45b4-b377-bfb74b6665ca:802-3-ethernet:",
+                    "enp2s0f2:a7199332-f99d-4152-babd-79d37d53478c:802-3-ethernet:",
+                    "enp2s0f3:86dbb462-6404-4444-8f4b-b78d045f4c9d:802-3-ethernet:"
+                ]
+            ),
+            ""
+        ),
         "nmcli connection show ovirtmgmt": (0, "", ""),
         "nmcli connection show ovirtmgmtt": (
             10,
@@ -79,15 +93,18 @@ class TestNmcliSanity(NmcliBase):
             "\n".join(
                 [
                     "NAME:                                   ovirtmgmt",
-                    "UUID:                                   f142311f-9e79-4b9e-9d8a-f591e0cec44a",  # noqa: E501
+                    "UUID:                                   f142311f-9e79-4b9e-9d8a-f591e0cec44a",
+                    # noqa: E501
                     "TYPE:                                   bridge",
                     "DEVICE:                                 ovirtmgmt",
                     "NAME:                                   virbr0",
-                    "UUID:                                   56d36466-2a58-4461-98ba-fbe11700955a",  # noqa: E501
+                    "UUID:                                   56d36466-2a58-4461-98ba-fbe11700955a",
+                    # noqa: E501
                     "TYPE:                                   bridge",
                     "DEVICE:                                 virbr0",
                     "NAME:                                   enp8s0f0",
-                    "UUID:                                   f58d1962-459d-47de-b090-55091dd3d702",  # noqa: E501
+                    "UUID:                                   f58d1962-459d-47de-b090-55091dd3d702",
+                    # noqa: E501
                     "TYPE:                                   ethernet",
                     "DEVICE:                                 enp8s0f0",
                 ]
@@ -154,6 +171,38 @@ class TestNmcliSanity(NmcliBase):
         ),
     }
 
+    def test_get_all_connections(self, mock):
+        connections = mock.network.nmcli.get_all_connections()
+        assert (
+                connections
+                == [
+                    {'device': 'virbr0',
+                     'name': 'virbr0',
+                     'type': 'bridge',
+                     'uuid': 'ba7aafc8-438e-4f8d-9f6e-3991fecebac0'},
+                    {'device': '',
+                     'name': 'enp1s0f1',
+                     'type': '802-3-ethernet',
+                     'uuid': '702b48ac-750f-4856-8124-c8c55d8e3dda'},
+                    {'device': '',
+                     'name': 'enp2s0f0',
+                     'type': '802-3-ethernet',
+                     'uuid': 'd2ee2c05-b28f-4529-8f42-ea4dbb17f308'},
+                    {'device': '',
+                     'name': 'enp2s0f1',
+                     'type': '802-3-ethernet',
+                     'uuid': '98e5c49f-bd72-45b4-b377-bfb74b6665ca'},
+                    {'device': '',
+                     'name': 'enp2s0f2',
+                     'type': '802-3-ethernet',
+                     'uuid': 'a7199332-f99d-4152-babd-79d37d53478c'},
+                    {'device': '',
+                     'name': 'enp2s0f3',
+                     'type': '802-3-ethernet',
+                     'uuid': '86dbb462-6404-4444-8f4b-b78d045f4c9d'}
+                ]
+        )
+
     def test_set_connection_up(self, mock):
         mock.network.nmcli.set_connection_state(
             connection="ovirtmgmt", state="up"
@@ -166,8 +215,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_set_non_existing_connection_up(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: unknown connection 'ovirtmgmtt'..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.set_connection_state(
                 connection="ovirtmgmtt", state="up"
@@ -175,8 +224,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_set_non_existing_connection_down(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: unknown connection 'ovirtmgmtt'..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.set_connection_state(
                 connection="ovirtmgmtt", state="down"
@@ -195,8 +244,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_modify_non_existing_connection(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: unknown connection 'ovirtmgmtt'..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.modify_connection(
                 connection="ovirtmgmtt", properties={"autoconnect": "yes"}
@@ -207,8 +256,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_delete_non_existing_connection(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: unknown connection 'ovirtmgmtt'..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.delete_connection(connection="ovirtmgmtt")
 
@@ -410,10 +459,10 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv4_address(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv4.addresses: "
-            "invalid IP address: "
-            "Invalid IPv4 address '192.186.23.2.2'..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: failed to modify ipv4.addresses: "
+                      "invalid IP address: "
+                      "Invalid IPv4 address '192.186.23.2.2'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -428,11 +477,11 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv6_address(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv6.addresses: "
-            "invalid IP address: "
-            "Invalid IPv6 address "
-            "'2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: failed to modify ipv6.addresses: "
+                      "invalid IP address: "
+                      "Invalid IPv6 address "
+                      "'2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -447,10 +496,10 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv4_gateway(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv4.gateway: "
-            "invalid IP address: "
-            "Invalid IPv4 address '192.168.23.254.2'.*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: failed to modify ipv4.gateway: "
+                      "invalid IP address: "
+                      "Invalid IPv4 address '192.168.23.254.2'.*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -465,10 +514,10 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv6_gateway(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv6.gateway: "
-            "invalid IP address: "
-            "Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: failed to modify ipv6.gateway: "
+                      "invalid IP address: "
+                      "Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -488,9 +537,9 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_ethernet_with_invalid_mac(self, mock):
         with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify 802-3-ethernet.mac-address: "
-            "'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",
+                expected_exception=CommandExecutionFailure,
+                match=".*Error: failed to modify 802-3-ethernet.mac-address: "
+                      "'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3"

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -52,8 +52,8 @@ class TestNmcliSanity(NmcliBase):
     """
 
     data = {
-        "nmcli con show ovirtmgmt": (0, "", ""),
-        "nmcli con show ovirtmgmtt": (
+        "nmcli connection show ovirtmgmt": (0, "", ""),
+        "nmcli connection show ovirtmgmtt": (
             10,
             "",
             "Error: ovirtmgmtt - no such connection profile.",
@@ -114,12 +114,14 @@ class TestNmcliSanity(NmcliBase):
         ),
         "nmcli connection up ovirtmgmt": (
             0,
-            "Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
+            "Connection successfully activated (D-Bus active path: "
+            "/org/freedesktop/NetworkManager/ActiveConnection/1985)",
             "",
         ),
         "nmcli connection down ovirtmgmt": (
             0,
-            "Connection successfully terminated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
+            "Connection successfully terminated (D-Bus active path: "
+            "/org/freedesktop/NetworkManager/ActiveConnection/1985)",
             "",
         ),
         "nmcli connection up ovirtmgmtt": (
@@ -132,36 +134,25 @@ class TestNmcliSanity(NmcliBase):
             "",
             "Error: unknown connection 'ovirtmgmtt'.",
         ),
-        "nmcli con delete ovirtmgmt": (
+        "nmcli connection delete ovirtmgmt": (
             0,
-            "Connection successfully removed (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
+            "Connection successfully removed (D-Bus active path: "
+            "/org/freedesktop/NetworkManager/ActiveConnection/1985)",
             "",
         ),
-        "nmcli con delete ovirtmgmtt": (
+        "nmcli connection delete ovirtmgmtt": (
             10,
             "",
             "Error: unknown connection 'ovirtmgmtt'.",
         ),
-        "nmcli con modify ovirtmgmt autoconnect yes": (0, "", ""),
-        "nmcli con modify ovirtmgmt autoconnectt yes": (10, "", ""),
-        "nmcli con modify ovirtmgmtt autoconnect yes": (
+        "nmcli connection modify ovirtmgmt autoconnect yes": (0, "", ""),
+        "nmcli connection modify ovirtmgmt autoconnectt yes": (10, "", ""),
+        "nmcli connection modify ovirtmgmtt autoconnect yes": (
             10,
             "",
             "Error: unknown connection 'ovirtmgmtt'.",
         ),
     }
-
-    def test_get_device_type(self, mock):
-        assert (
-            mock.network.nmcli.get_device_type(device="enp8s0f0") == "ethernet"
-        )
-
-    def test_get_non_existing_device_type(self, mock):
-        with pytest.raises(
-            expected_exception=CommandExecutionFailure,
-            match="Error: Device 'enp8s0f00' not found.",
-        ):
-            mock.network.nmcli.get_device_type(device="enp8s0f00")
 
     def test_set_connection_up(self, mock):
         mock.network.nmcli.set_connection_state(
@@ -265,92 +256,100 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     data = {
         (
-            "nmcli con add type ethernet con-name ethernet_con ifname enp8s0f0"
-        ): (
-            0,
-            "",
-            "",
-        ),
-        (
-            "nmcli con add "
-            "type ethernet con-name ethernet_con ifname enp8s0f0 autoconnect yes"  # noqa: E501
+            "nmcli connection add type ethernet con-name ethernet_con ifname "
+            "enp8s0f0"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 autoconnect "
+            "yes"
+        ): (0, "", ""),
+        (
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 save yes"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (
             10,
             "",
-            "Error: failed to modify ipv4.addresses: invalid IP address: Invalid IPv4 address '192.186.23.2.2'.",  # noqa: E501
+            "Error: failed to modify ipv4.addresses: invalid IP address: "
+            "Invalid IPv4 address '192.186.23.2.2'.",
         ),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (
             10,
             "",
-            "Error: failed to modify ipv6.addresses: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:dc3f:f939:a573'.",  # noqa: E501
+            "Error: failed to modify ipv6.addresses: invalid IP address: "
+            "Invalid IPv6 address '2a02:ed0:52fe:ec00:dc3f:f939:a573'.",
         ),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (
             10,
             "",
-            "Error: failed to modify ipv4.gateway: invalid IP address: Invalid IPv4 address '192.168.23.254.2'.",  # noqa: E501
+            "Error: failed to modify ipv4.gateway: invalid IP address: "
+            "Invalid IPv4 address '192.168.23.254.2'.",
         ),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00:"
         ): (
             10,
             "",
-            "Error: failed to modify ipv6.gateway: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:'.",  # noqa: E501
+            "Error: failed to modify ipv6.gateway: invalid IP address: "
+            "Invalid IPv6 address '2a02:ed0:52fe:ec00:'.",
         ),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "mac e8:6a:64:7d:d3:b1"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "mac e8:6a:64:7d:d3"
         ): (
             10,
             "",
-            "Error: failed to modify 802-3-ethernet.mac-address: 'e8:6a:64:7d:d3' is not a valid Ethernet MAC.",  # noqa: E501
+            "Error: failed to modify 802-3-ethernet.mac-address: "
+            "'e8:6a:64:7d:d3' is not a valid Ethernet MAC.",
         ),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "mtu 1600"
         ): (0, "", ""),
@@ -358,22 +357,22 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_defaults(self, mock):
         mock.network.nmcli.add_ethernet_connection(
-            con_name="ethernet_con", ifname="enp8s0f0"
+            name="ethernet_con", ifname="enp8s0f0"
         )
 
     def test_add_connection_with_autoconnect(self, mock):
         mock.network.nmcli.add_ethernet_connection(
-            con_name="ethernet_con", ifname="enp8s0f0", auto_connect=True
+            name="ethernet_con", ifname="enp8s0f0", auto_connect=True
         )
 
     def test_add_connection_with_save(self, mock):
         mock.network.nmcli.add_ethernet_connection(
-            con_name="ethernet_con", ifname="enp8s0f0", save=True
+            name="ethernet_con", ifname="enp8s0f0", save=True
         )
 
     def test_add_connection_with_static_ips(self, mock):
         mock.network.nmcli.add_ethernet_connection(
-            con_name="ethernet_con",
+            name="ethernet_con",
             ifname="enp8s0f0",
             ipv4_method="manual",
             ipv4_addr="192.168.23.2",
@@ -386,10 +385,12 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
     def test_add_connection_with_invalid_ipv4_address(self, mock):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv4.addresses: invalid IP address: Invalid IPv4 address '192.186.23.2.2'..*",  # noqa: E501
+            match=".*Error: failed to modify ipv4.addresses: "
+                  "invalid IP address: "
+                  "Invalid IPv4 address '192.186.23.2.2'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
-                con_name="ethernet_con",
+                name="ethernet_con",
                 ifname="enp8s0f0",
                 ipv4_method="manual",
                 ipv4_addr="192.168.23.2.2",
@@ -402,10 +403,13 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
     def test_add_connection_with_invalid_ipv6_address(self, mock):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv6.addresses: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",  # noqa: E501
+            match=".*Error: failed to modify ipv6.addresses: "
+                  "invalid IP address: "
+                  "Invalid IPv6 address "
+                  "'2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
-                con_name="ethernet_con",
+                name="ethernet_con",
                 ifname="enp8s0f0",
                 ipv4_method="manual",
                 ipv4_addr="192.168.23.2",
@@ -418,10 +422,12 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
     def test_add_connection_with_invalid_ipv4_gateway(self, mock):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv4.gateway: invalid IP address: Invalid IPv4 address '192.168.23.254.2'.*",  # noqa: E501
+            match=".*Error: failed to modify ipv4.gateway: "
+                  "invalid IP address: "
+                  "Invalid IPv4 address '192.168.23.254.2'.*",
         ):
             mock.network.nmcli.add_ethernet_connection(
-                con_name="ethernet_con",
+                name="ethernet_con",
                 ifname="enp8s0f0",
                 ipv4_method="manual",
                 ipv4_addr="192.168.23.2",
@@ -434,10 +440,12 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
     def test_add_connection_with_invalid_ipv6_gateway(self, mock):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify ipv6.gateway: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",  # noqa: E501
+            match=".*Error: failed to modify ipv6.gateway: "
+                  "invalid IP address: "
+                  "Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
-                con_name="ethernet_con",
+                name="ethernet_con",
                 ifname="enp8s0f0",
                 ipv4_method="manual",
                 ipv4_addr="192.168.23.2",
@@ -449,23 +457,22 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_ethernet_with_mac(self, mock):
         mock.network.nmcli.add_ethernet_connection(
-            con_name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3:b1"
+            name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3:b1"
         )
 
     def test_add_ethernet_with_invalid_mac(self, mock):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
-            match=".*Error: failed to modify 802-3-ethernet.mac-address: 'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",  # noqa: E501
+            match=".*Error: failed to modify 802-3-ethernet.mac-address: "
+                  "'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
-                con_name="ethernet_con",
-                ifname="enp8s0f0",
-                mac="e8:6a:64:7d:d3",
+                name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3"
             )
 
     def test_add_ethernet_with_mtu(self, mock):
         mock.network.nmcli.add_ethernet_connection(
-            con_name="ethernet_con", ifname="enp8s0f0", mtu=1600
+            name="ethernet_con", ifname="enp8s0f0", mtu=1600
         )
 
 
@@ -475,25 +482,20 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
     """
 
     data = {
-        "nmcli con add " "type bond con-name bond_con ifname bond0": (
-            0,
-            "",
-            "",
-        ),
+        "nmcli connection add "
+        "type bond con-name bond_con ifname bond0": (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect yes"
         ): (0, "", ""),
         (
-            "nmcli con add " "type bond con-name bond_con ifname bond0 " "save yes"  # noqa: E501
-        ): (
-            0,
-            "",
-            "",
-        ),
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "save yes"
+        ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254 "
@@ -501,7 +503,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2.2 ipv4.gateway 192.168.23.254 "
@@ -509,7 +511,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254.2 "
@@ -517,7 +519,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254 "
@@ -525,7 +527,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254 "
@@ -533,39 +535,39 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00:"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "mode balance-rr"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "mode active-backup"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "mode balance-xor"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "mode broadcast"
         ): (0, "", ""),
-        "nmcli con add "
+        "nmcli connection add "
         "type bond con-name bond_con ifname bond0 "
         "mode 802.3ad": (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "mode balance-tlb"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "mode balance-alb"
         ): (0, "", ""),
-        "nmcli con add "
+        "nmcli connection add "
         "type bond con-name bond_con ifname bond0 "
         "miimon 50": (0, "", ""),
     }
@@ -677,16 +679,16 @@ class TestNmcliSlaveConnection(NmcliConnectionTypeBase):
 
     data = {
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name bond0_slave ifname enp8s0f0 master bond0"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name bond0_slave ifname enp8s0f0 "
             "autoconnect yes master bond0"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type ethernet con-name bond0_slave ifname enp8s0f0 "
             "save yes master bond0"
         ): (0, "", ""),
@@ -695,12 +697,16 @@ class TestNmcliSlaveConnection(NmcliConnectionTypeBase):
 
     def test_add_connection_defaults(self, mock):
         mock.network.nmcli.add_slave(
-            con_name="bond0_slave", ifname="enp8s0f0", master="bond0"
+            con_name="bond0_slave",
+            slave_type="ethernet",
+            ifname="enp8s0f0",
+            master="bond0",
         )
 
     def test_add_connection_with_autoconnect(self, mock):
         mock.network.nmcli.add_slave(
             con_name="bond0_slave",
+            slave_type="ethernet",
             ifname="enp8s0f0",
             master="bond0",
             auto_connect=True,
@@ -709,6 +715,7 @@ class TestNmcliSlaveConnection(NmcliConnectionTypeBase):
     def test_add_connection_with_save(self, mock):
         mock.network.nmcli.add_slave(
             con_name="bond0_slave",
+            slave_type="ethernet",
             ifname="enp8s0f0",
             master="bond0",
             save=True,
@@ -722,35 +729,35 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
 
     data = {
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "autoconnect yes id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "autoconnect yes dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "save yes id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "save yes dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
             "ipv4.method manual ipv6.method manual "
@@ -759,7 +766,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
@@ -768,7 +775,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
             "ipv4.method manual ipv6.method manual "
@@ -777,7 +784,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
@@ -786,86 +793,92 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 id 163 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 id 163 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00:"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 id 163 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00:"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 mtu 1600"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "mtu 1600 id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 id 163 mtu 1600"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "dev enp8s0f0 mtu 1600 id 163"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "mtu 1600 dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 mtu 1600 dev enp8s0f0"
         ): (0, "", ""),
@@ -875,9 +888,9 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "",
             "Error: Device 'enp8s0f00' not found.",
         ),
-        "nmcli con add type vlan con-name vlan_con ifname enp8s0f00 "
+        "nmcli connection add type vlan con-name vlan_con ifname enp8s0f00 "
         "id 163 dev enp8s0f00": (10, "", ""),
-        "nmcli con add type vlan con-name vlan_con ifname enp8s0f00 "
+        "nmcli connection add type vlan con-name vlan_con ifname enp8s0f00 "
         "dev enp8s0f00 id 163": (10, "", ""),
     }
 
@@ -983,52 +996,57 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
     """
 
     data = {
-        "nmcli con add "
+        "nmcli connection add "
         "type dummy con-name dummy_con ifname dummy_0": (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
             "autoconnect yes"
         ): (0, "", ""),
-        "nmcli con add "
+        "nmcli connection add "
         "type dummy con-name dummy_con ifname dummy_0 "
         "save yes": (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (0, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573 "
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (10, "", ""),
         (
-            "nmcli con add "
+            "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
-            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
             "ipv6.gateway 2a02:ed0:52fe:ec00:"

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -197,7 +197,25 @@ class TestNmcliSanity(NmcliBase):
             "",
             "Error: unknown connection 'ovirtmgmtt'.",
         ),
+        "nmcli device modify em1 +ipv4.dns 8.8.4.4": (0, "", ""),
+        'nmcli device modify em1 -ipv6.addr abbe::cafe/56': (0, "", "")
     }
+
+    def test_modify_device_add_ipv4_dns(self, mock):
+        mock.network.nmcli.modify_device(
+            device="em1",
+            properties={
+                "+ipv4.dns": "8.8.4.4"
+            }
+        )
+
+    def test_modify_device_remove_ipv6_address(self, mock):
+        mock.network.nmcli.modify_device(
+            device="em1",
+            properties={
+                "-ipv6.addr": "abbe::cafe/56"
+            }
+        )
 
     def test_get_all_connections(self, mock):
         connections = mock.network.nmcli.get_all_connections()

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -10,7 +10,8 @@ from rrmngmnt.nmcli import (
     ConnectionDoesNotExistException,
     DeviceDoesNotExistException,
     InvalidIPException,
-    InvalidMACException)
+    InvalidMACException,
+)
 from tests.common import FakeExecutorFactory
 
 MOCK_ROOT_PASSWORD = "11111"
@@ -29,9 +30,7 @@ def provision_host(request):
 
     mock = Host(ip=ip)
     mock.add_user(RootUser(password=root_password))
-    mock.executor_factory = FakeExecutorFactory(
-        cmd_to_data=data, files_content=None
-    )
+    mock.executor_factory = FakeExecutorFactory(cmd_to_data=data, files_content=None)  # noqa: E501
     return mock
 
 
@@ -44,6 +43,7 @@ class NmcliBase(object):
     """
     Base class for tests
     """
+
     host_ip = MOCK_IP
     root_password = MOCK_ROOT_PASSWORD
     data = {}
@@ -53,36 +53,29 @@ class TestNmcliSanity(NmcliBase):
     """
     Testing basic scenarios for existing connections.
     """
+
     data = {
-        "nmcli connection show ovirtmgmt": (
-            0,
-            "",
-            ""
-        ),
+        "nmcli connection show ovirtmgmt": (0, "", ""),
         "nmcli connection show ovirtmgmtt": (
             10,
             "",
-            "Error: ovirtmgmtt - no such connection profile."
+            "Error: ovirtmgmtt - no such connection profile.",
         ),
-        "nmcli device show ovirtmgmt": (
-            0,
-            "",
-            ""
-        ),
+        "nmcli device show ovirtmgmt": (0, "", ""),
         "nmcli device show ovirtmgmtt": (
             10,
             "",
-            "Error: Device 'ovirtmgmtt' not found."
+            "Error: Device 'ovirtmgmtt' not found.",
         ),
         "nmcli -g connection.uuid connection show ovirtmgmt": (
             0,
             "f142311f-9e79-4b9e-9d8a-f591e0cec44a",
-            ""
+            "",
         ),
         "nmcli -g connection.uuid connection show ovirtmgmtt": (
             10,
             "",
-            "Error: ovirtmgmtt - no such connection profile"
+            "Error: ovirtmgmtt - no such connection profile",
         ),
         "nmcli -m multiline connection show": (
             0,
@@ -99,85 +92,65 @@ class TestNmcliSanity(NmcliBase):
                     "NAME:                                   enp8s0f0",
                     "UUID:                                   f58d1962-459d-47de-b090-55091dd3d702",  # noqa: E501
                     "TYPE:                                   ethernet",
-                    "DEVICE:                                 enp8s0f0"
+                    "DEVICE:                                 enp8s0f0",
                 ]
             ),
-            ""
-        ),
-        "nmcli connection show virbr0": (
-            0,
             "",
-            ""
         ),
-        "nmcli connection show enp8s0f0": (
-            0,
-            "",
-            ""
-        ),
+        "nmcli connection show virbr0": (0, "", ""),
+        "nmcli connection show enp8s0f0": (0, "", ""),
         "nmcli -g connection.uuid connection show virbr0": (
             0,
             "56d36466-2a58-4461-98ba-fbe11700955a",
-            ""
+            "",
         ),
         "nmcli -g connection.uuid connection show enp8s0f0": (
             0,
             "f58d1962-459d-47de-b090-55091dd3d702",
-            ""
+            "",
         ),
-        "nmcli -g GENERAL.TYPE device show enp8s0f0": (
-            0,
-            "ethernet",
-            ""
-        ),
+        "nmcli -g GENERAL.TYPE device show enp8s0f0": (0, "ethernet", ""),
         "nmcli -g GENERAL.TYPE device show enp8s0f00": (
             10,
             "",
-            "Error: Device 'enp8s0f00' not found."
+            "Error: Device 'enp8s0f00' not found.",
         ),
         "nmcli connection up ovirtmgmt": (
             0,
             "Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
-            ""
+            "",
         ),
         "nmcli connection down ovirtmgmt": (
             0,
             "Connection successfully terminated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
-            ""
+            "",
         ),
         "nmcli connection up ovirtmgmtt": (
             10,
             "",
-            "Error: unknown connection 'ovirtmgmtt'."
+            "Error: unknown connection 'ovirtmgmtt'.",
         ),
         "nmcli connection down ovirtmgmtt": (
             10,
             "",
-            "Error: unknown connection 'ovirtmgmtt'."
+            "Error: unknown connection 'ovirtmgmtt'.",
         ),
         "nmcli connection delete ovirtmgmt": (
             0,
             "Connection successfully removed (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
-            ""
+            "",
         ),
         "nmcli connection delete ovirtmgmtt": (
             10,
             "",
-            "Error: unknown connection 'ovirtmgmtt'."
+            "Error: unknown connection 'ovirtmgmtt'.",
         ),
-        "nmcli connection modify ovirtmgmt autoconnect yes": (
-            0,
-            "",
-            ""
-        ),
-        "nmcli connection modify ovirtmgmt autoconnectt yes": (
-            10,
-            "",
-            ""
-        ),
+        "nmcli connection modify ovirtmgmt autoconnect yes": (0, "", ""),
+        "nmcli connection modify ovirtmgmt autoconnectt yes": (10, "", ""),
         "nmcli connection modify ovirtmgmtt autoconnect yes": (
             10,
             "",
-            "Error: unknown connection 'ovirtmgmtt'."
+            "Error: unknown connection 'ovirtmgmtt'.",
         ),
     }
 
@@ -185,9 +158,7 @@ class TestNmcliSanity(NmcliBase):
         assert mock.network.nmcli.is_connection_exist(connection="ovirtmgmt")
 
     def test_check_connection_exists_when_it_does_not(self, mock):
-        assert not mock.network.nmcli.is_connection_exist(
-            connection="ovirtmgmtt"
-        )
+        assert not mock.network.nmcli.is_connection_exist(connection="ovirtmgmtt")  # noqa: E501
 
     def test_check_device_exists(self, mock):
         assert mock.network.nmcli.is_device_exist(device="ovirtmgmt")
@@ -197,63 +168,52 @@ class TestNmcliSanity(NmcliBase):
 
     def test_get_connection_uuid(self, mock):
         assert (
-                mock.network.nmcli.get_connection_uuid(con_name="ovirtmgmt")
-                == "f142311f-9e79-4b9e-9d8a-f591e0cec44a"
+            mock.network.nmcli.get_connection_uuid(con_name="ovirtmgmt")
+            == "f142311f-9e79-4b9e-9d8a-f591e0cec44a"
         )
 
     def test_get_non_existing_connection_uuid(self, mock):
         with pytest.raises(
             expected_exception=ConnectionDoesNotExistException,
-            match="connection ovirtmgmtt does not exist"
+            match="connection ovirtmgmtt does not exist",
         ):
-            mock.network.nmcli.get_connection_uuid(
-                con_name="ovirtmgmtt"
-            )
+            mock.network.nmcli.get_connection_uuid(con_name="ovirtmgmtt")
 
     def test_get_all_existing_connections_uuids(self, mock):
         all_cons_uuids = mock.network.nmcli.get_all_connections_uuids()
         assert all_cons_uuids == [
             "f142311f-9e79-4b9e-9d8a-f591e0cec44a",
             "56d36466-2a58-4461-98ba-fbe11700955a",
-            "f58d1962-459d-47de-b090-55091dd3d702"
+            "f58d1962-459d-47de-b090-55091dd3d702",
         ]
 
     def test_get_device_type(self, mock):
-        assert (
-                mock.network.nmcli.get_device_type(device="enp8s0f0")
-                == "ethernet"
-        )
+        assert mock.network.nmcli.get_device_type(device="enp8s0f0") == "ethernet"  # noqa: E501
 
     def test_get_non_existing_device_type(self, mock):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
-            match="Error: Device 'enp8s0f00' not found."
+            match="Error: Device 'enp8s0f00' not found.",
         ):
             mock.network.nmcli.get_device_type(device="enp8s0f00")
 
     def test_set_connection_up(self, mock):
-        mock.network.nmcli.set_connection_state(
-            connection="ovirtmgmt", state="up"
-        )
+        mock.network.nmcli.set_connection_state(connection="ovirtmgmt", state="up")  # noqa: E501
 
     def test_set_connection_down(self, mock):
-        mock.network.nmcli.set_connection_state(
-            connection="ovirtmgmt", state="down"
-        )
+        mock.network.nmcli.set_connection_state(connection="ovirtmgmt", state="down")  # noqa: E501
 
     def test_set_non_existing_connection_up(self, mock):
         with pytest.raises(
-                expected_exception=ConnectionDoesNotExistException,
-                match="connection ovirtmgmtt does not exist"
+            expected_exception=ConnectionDoesNotExistException,
+            match="connection ovirtmgmtt does not exist",
         ):
-            mock.network.nmcli.set_connection_state(
-                connection="ovirtmgmtt", state="up"
-            )
+            mock.network.nmcli.set_connection_state(connection="ovirtmgmtt", state="up")  # noqa: E501
 
     def test_set_non_existing_connection_down(self, mock):
         with pytest.raises(
-                expected_exception=ConnectionDoesNotExistException,
-                match="connection ovirtmgmtt does not exist"
+            expected_exception=ConnectionDoesNotExistException,
+            match="connection ovirtmgmtt does not exist",
         ):
             mock.network.nmcli.set_connection_state(
                 connection="ovirtmgmtt", state="down"
@@ -261,27 +221,22 @@ class TestNmcliSanity(NmcliBase):
 
     def test_modify_connection_autoconnect(self, mock):
         mock.network.nmcli.modify_connection(
-            connection="ovirtmgmt",
-            properties={"autoconnect": "yes"}
+            connection="ovirtmgmt", properties={"autoconnect": "yes"}
         )
 
     def test_modify_connection_with_illegal_property(self, mock):
-        with pytest.raises(
-            expected_exception=CommandExecutionFailure
-        ):
+        with pytest.raises(expected_exception=CommandExecutionFailure):
             mock.network.nmcli.modify_connection(
-                connection="ovirtmgmt",
-                properties={"autoconnectt": "yes"}
+                connection="ovirtmgmt", properties={"autoconnectt": "yes"}
             )
 
     def test_modify_non_existing_connection(self, mock):
         with pytest.raises(
             expected_exception=ConnectionDoesNotExistException,
-            match="connection ovirtmgmtt does not exist"
+            match="connection ovirtmgmtt does not exist",
         ):
             mock.network.nmcli.modify_connection(
-                connection="ovirtmgmtt",
-                properties={"autoconnect": "yes"}
+                connection="ovirtmgmtt", properties={"autoconnect": "yes"}
             )
 
     def test_delete_connection(self, mock):
@@ -289,8 +244,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_delete_non_existing_connection(self, mock):
         with pytest.raises(
-                expected_exception=ConnectionDoesNotExistException,
-                match="connection ovirtmgmtt does not exist"
+            expected_exception=ConnectionDoesNotExistException,
+            match="connection ovirtmgmtt does not exist",
         ):
             mock.network.nmcli.delete_connection(connection="ovirtmgmtt")
 
@@ -299,6 +254,7 @@ class NmcliConnectionTypeBase(NmcliBase):
     """
     Base class for testing different connection types.
     """
+
     def test_add_connection_defaults(self, mock):
         pass
 
@@ -313,6 +269,7 @@ class NmcliConnectionTypeIPConfigurable(NmcliConnectionTypeBase):
     """
     Base class for testing connection types where IPv4/6 can be configured.
     """
+
     def test_add_connection_with_static_ips(self, mock):
         pass
 
@@ -333,34 +290,23 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
     """
     Testing scenarios for ethernet type connections.
     """
+
     data = {
         (
             "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "autoconnect no save no"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "autoconnect yes save no"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "autoconnect no save yes"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
@@ -369,11 +315,7 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
@@ -385,7 +327,7 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         ): (
             10,
             "",
-            "Error: failed to modify ipv4.addresses: invalid IP address: Invalid IPv4 address '192.186.23'."  # noqa: E501
+            "Error: failed to modify ipv4.addresses: invalid IP address: Invalid IPv4 address '192.186.23'.",  # noqa: E501
         ),
         (
             "nmcli connection add "
@@ -398,7 +340,7 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         ): (
             10,
             "",
-            "Error: failed to modify ipv6.addresses: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:dc3f:f939:a573'."  # noqa: E501
+            "Error: failed to modify ipv6.addresses: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:dc3f:f939:a573'.",  # noqa: E501
         ),
         (
             "nmcli connection add "
@@ -411,7 +353,7 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         ): (
             10,
             "",
-            "Error: failed to modify ipv4.gateway: invalid IP address: Invalid IPv4 address '192.186.23'."  # noqa: E501
+            "Error: failed to modify ipv4.gateway: invalid IP address: Invalid IPv4 address '192.186.23'.",  # noqa: E501
         ),
         (
             "nmcli connection add "
@@ -424,48 +366,33 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         ): (
             10,
             "",
-            "Error: failed to modify ipv6.gateway: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:'."  # noqa: E501
+            "Error: failed to modify ipv6.gateway: invalid IP address: Invalid IPv6 address '2a02:ed0:52fe:ec00:'.",  # noqa: E501
         ),
         (
             "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "autoconnect no save no "
             "mac e8:6a:64:7d:d3:b1"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 "
             "autoconnect no save no "
             "mtu 1600"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
     }
 
     def test_add_connection_defaults(self, mock):
-        mock.network.nmcli.add_ethernet(
-            con_name="ethernet_con",
-            ifname="enp8s0f0"
-        )
+        mock.network.nmcli.add_ethernet(con_name="ethernet_con", ifname="enp8s0f0")  # noqa: E501
 
     def test_add_connection_with_autoconnect(self, mock):
         mock.network.nmcli.add_ethernet(
-            con_name="ethernet_con",
-            ifname="enp8s0f0",
-            auto_connect=True
+            con_name="ethernet_con", ifname="enp8s0f0", auto_connect=True
         )
 
     def test_add_connection_with_save(self, mock):
         mock.network.nmcli.add_ethernet(
-            con_name="ethernet_con",
-            ifname="enp8s0f0",
-            save=True
+            con_name="ethernet_con", ifname="enp8s0f0", save=True
         )
 
     def test_add_connection_with_static_ips(self, mock):
@@ -477,13 +404,13 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
             ipv4_gw="192.168.23.254",
             ipv6_method="manual",
             ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-            ipv6_gw="2a02:ed0:52fe:ec00::"
+            ipv6_gw="2a02:ed0:52fe:ec00::",
         )
 
     def test_add_connection_with_invalid_ipv4_address(self, mock):
         with pytest.raises(
             expected_exception=InvalidIPException,
-            match="IP address 192.168.23.2.2 is in-valid"
+            match="IP address 192.168.23.2.2 is in-valid",
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="ethernet_con",
@@ -493,13 +420,13 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_address(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid"  # noqa: E501
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid",  # noqa: E501
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="ethernet_con",
@@ -509,13 +436,13 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv4_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 192.168.23.254.2 is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 192.168.23.254.2 is in-valid",
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="ethernet_con",
@@ -525,13 +452,13 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254.2",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00: is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00: is in-valid",
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="ethernet_con",
@@ -541,32 +468,26 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00:"
+                ipv6_gw="2a02:ed0:52fe:ec00:",
             )
 
     def test_add_ethernet_with_mac(self, mock):
         mock.network.nmcli.add_ethernet(
-            con_name="ethernet_con",
-            ifname="enp8s0f0",
-            mac="e8:6a:64:7d:d3:b1"
+            con_name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3:b1"
         )
 
     def test_add_ethernet_with_invalid_mac(self, mock):
         with pytest.raises(
             expected_exception=InvalidMACException,
-            match="MAC address e8:6a:64:7d:d3 is invalid"
+            match="MAC address e8:6a:64:7d:d3 is invalid",
         ):
             mock.network.nmcli.add_ethernet(
-                con_name="ethernet_con",
-                ifname="enp8s0f0",
-                mac="e8:6a:64:7d:d3"
+                con_name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3"  # noqa: E501
             )
 
     def test_add_ethernet_with_mtu(self, mock):
         mock.network.nmcli.add_ethernet(
-            con_name="ethernet_con",
-            ifname="enp8s0f0",
-            mtu=1600
+            con_name="ethernet_con", ifname="enp8s0f0", mtu=1600
         )
 
 
@@ -574,34 +495,23 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
     """
     Testing scenarios for bond type connections.
     """
+
     data = {
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode active-backup miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect yes save no mode active-backup miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save yes mode active-backup miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
@@ -610,11 +520,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
@@ -623,11 +529,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            10,
-            "",
-            ""
-        ),
+        ): (10, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
@@ -636,11 +538,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
@@ -649,11 +547,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
@@ -662,104 +556,59 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00:"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode balance-rr miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode active-backup miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode balance-xor miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode broadcast miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode 802.3ad miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode balance-tlb miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode balance-alb miimon 100"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name bond_con ifname bond0 "
             "autoconnect no save no mode active-backup miimon 50"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
     }
 
     def test_add_connection_defaults(self, mock):
-        mock.network.nmcli.add_bond(
-            con_name="bond_con",
-            ifname="bond0"
-        )
+        mock.network.nmcli.add_bond(con_name="bond_con", ifname="bond0")
 
     def test_add_connection_with_autoconnect(self, mock):
         mock.network.nmcli.add_bond(
-            con_name="bond_con",
-            ifname="bond0",
-            auto_connect=True
+            con_name="bond_con", ifname="bond0", auto_connect=True
         )
 
     def test_add_connection_with_save(self, mock):
-        mock.network.nmcli.add_bond(
-            con_name="bond_con",
-            ifname="bond0",
-            save=True
-        )
+        mock.network.nmcli.add_bond(con_name="bond_con", ifname="bond0", save=True)  # noqa: E501
 
     def test_add_connection_with_static_ips(self, mock):
         mock.network.nmcli.add_bond(
@@ -770,7 +619,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             ipv4_gw="192.168.23.254",
             ipv6_method="manual",
             ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-            ipv6_gw="2a02:ed0:52fe:ec00::"
+            ipv6_gw="2a02:ed0:52fe:ec00::",
         )
 
     @pytest.mark.parametrize(
@@ -782,27 +631,19 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
             "broadcast",
             "802.3ad",
             "balance-tlb",
-            "balance-alb"
-        ]
+            "balance-alb",
+        ],
     )
     def test_add_bond_with_mode(self, mock, bond_mode):
-        mock.network.nmcli.add_bond(
-            con_name="bond_con",
-            ifname="bond0",
-            mode=bond_mode
-        )
+        mock.network.nmcli.add_bond(con_name="bond_con", ifname="bond0", mode=bond_mode)  # noqa: E501
 
     def test_add_bond_with_miimon(self, mock):
-        mock.network.nmcli.add_bond(
-            con_name="bond_con",
-            ifname="bond0",
-            miimon=50
-        )
+        mock.network.nmcli.add_bond(con_name="bond_con", ifname="bond0", miimon=50)  # noqa: E501
 
     def test_add_connection_with_invalid_ipv4_address(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 192.168.23.2.2 is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 192.168.23.2.2 is in-valid",
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="bond_con",
@@ -812,13 +653,14 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_address(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid"  # noqa: E501
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid"
+            # noqa: E501
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="bond_con",
@@ -828,13 +670,13 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv4_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 192.168.23.254.2 is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 192.168.23.254.2 is in-valid",
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="bond_con",
@@ -844,13 +686,13 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254.2",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00: is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00: is in-valid",
         ):
             mock.network.nmcli.add_ethernet(
                 con_name="bond_con",
@@ -860,7 +702,7 @@ class TestNmcliBondConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00:"
+                ipv6_gw="2a02:ed0:52fe:ec00:",
             )
 
 
@@ -868,62 +710,39 @@ class TestNmcliSlaveConnection(NmcliConnectionTypeBase):
     """
     Testing scenarios for bond type connections.
     """
+
     data = {
         (
             "nmcli connection add "
             "type ethernet con-name bond0_slave ifname enp8s0f0 "
             "autoconnect no save no master bond0"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type ethernet con-name bond0_slave ifname enp8s0f0 "
             "autoconnect yes save no master bond0"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type ethernet con-name bond0_slave ifname enp8s0f0 "
             "autoconnect no save yes master bond0"
-        ): (
-            0,
-            "",
-            ""
-        ),
-        "nmcli -g GENERAL.TYPE device show enp8s0f0": (
-            0,
-            "ethernet",
-            ""
-        ),
+        ): (0, "", ""),
+        "nmcli -g GENERAL.TYPE device show enp8s0f0": (0, "ethernet", ""),
     }
 
     def test_add_connection_defaults(self, mock):
         mock.network.nmcli.add_slave(
-            con_name="bond0_slave",
-            ifname="enp8s0f0",
-            master="bond0"
+            con_name="bond0_slave", ifname="enp8s0f0", master="bond0"
         )
 
     def test_add_connection_with_autoconnect(self, mock):
         mock.network.nmcli.add_slave(
-            con_name="bond0_slave",
-            ifname="enp8s0f0",
-            master="bond0",
-            auto_connect=True
+            con_name="bond0_slave", ifname="enp8s0f0", master="bond0", auto_connect=True  # noqa: E501
         )
 
     def test_add_connection_with_save(self, mock):
         mock.network.nmcli.add_slave(
-            con_name="bond0_slave",
-            ifname="enp8s0f0",
-            master="bond0",
-            save=True
+            con_name="bond0_slave", ifname="enp8s0f0", master="bond0", save=True  # noqa: E501
         )
 
 
@@ -931,37 +750,26 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
     """
     Testing scenarios for VLAN type connections.
     """
+
     data = {
         (
             "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "autoconnect no save no "
             "dev enp8s0f0 id 163"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "autoconnect yes save no "
             "dev enp8s0f0 id 163"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "autoconnect no save yes "
             "dev enp8s0f0 id 163"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
@@ -971,11 +779,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name vlan_con ifname enp8s0f0 "
@@ -984,11 +788,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            10,
-            "",
-            ""
-        ),
+        ): (10, "", ""),
         (
             "nmcli connection add "
             "type bond con-name vlan_con ifname enp8s0f0 "
@@ -997,11 +797,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name vlan_con ifname enp8s0f0 "
@@ -1010,11 +806,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type bond con-name vlan_con ifname enp8s0f0 "
@@ -1023,55 +815,29 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00:"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "autoconnect no save no "
             "dev enp8s0f0 id 163 "
             "mtu 1600"
-        ): (
-            0,
-            "",
-            ""
-        ),
-        "nmcli device show enp8s0f0": (
-            0,
-            "ethernet",
-            ""
-        ),
-        "nmcli device show enp8s0f00": (
-            10,
-            "",
-            "Error: Device 'enp8s0f00' not found."
-        ),
+        ): (0, "", ""),
+        "nmcli device show enp8s0f0": (0, "ethernet", ""),
+        "nmcli device show enp8s0f00": (10, "", "Error: Device 'enp8s0f00' not found."),  # noqa: E501
     }
 
     def test_add_connection_defaults(self, mock):
-        mock.network.nmcli.add_vlan(
-            con_name="vlan_con",
-            dev="enp8s0f0",
-            vlan_id=163
-        )
+        mock.network.nmcli.add_vlan(con_name="vlan_con", dev="enp8s0f0", vlan_id=163)  # noqa: E501
 
     def test_add_connection_with_autoconnect(self, mock):
         mock.network.nmcli.add_vlan(
-            con_name="vlan_con",
-            dev="enp8s0f0",
-            vlan_id=163,
-            auto_connect=True
+            con_name="vlan_con", dev="enp8s0f0", vlan_id=163, auto_connect=True
         )
 
     def test_add_connection_with_save(self, mock):
         mock.network.nmcli.add_vlan(
-            con_name="vlan_con",
-            dev="enp8s0f0",
-            vlan_id=163,
-            save=True
+            con_name="vlan_con", dev="enp8s0f0", vlan_id=163, save=True
         )
 
     def test_add_connection_with_static_ips(self, mock):
@@ -1084,32 +850,27 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             ipv4_gw="192.168.23.254",
             ipv6_method="manual",
             ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-            ipv6_gw="2a02:ed0:52fe:ec00::"
+            ipv6_gw="2a02:ed0:52fe:ec00::",
         )
 
     def test_add_vlan_with_invalid_dev(self, mock):
         with pytest.raises(
             expected_exception=DeviceDoesNotExistException,
-            match="device enp8s0f00 does not exist"
+            match="device enp8s0f00 does not exist",
         ):
             mock.network.nmcli.add_vlan(
-                con_name="vlan_con",
-                dev="enp8s0f00",
-                vlan_id=163
+                con_name="vlan_con", dev="enp8s0f00", vlan_id=163
             )
 
     def test_add_vlan_with_mtu(self, mock):
         mock.network.nmcli.add_vlan(
-            con_name="vlan_con",
-            dev="enp8s0f0",
-            vlan_id=163,
-            mtu=1600
+            con_name="vlan_con", dev="enp8s0f0", vlan_id=163, mtu=1600
         )
 
     def test_add_connection_with_invalid_ipv4_address(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 192.168.23.2.2 is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 192.168.23.2.2 is in-valid",
         ):
             mock.network.nmcli.add_vlan(
                 con_name="vlan_con",
@@ -1120,13 +881,14 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_address(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid"  # noqa: E501
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid"
+            # noqa: E501
         ):
             mock.network.nmcli.add_vlan(
                 con_name="vlan_con",
@@ -1137,13 +899,13 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv4_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 192.168.23.254.2 is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 192.168.23.254.2 is in-valid",
         ):
             mock.network.nmcli.add_vlan(
                 con_name="vlan_con",
@@ -1154,13 +916,13 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254.2",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00: is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00: is in-valid",
         ):
             mock.network.nmcli.add_vlan(
                 con_name="vlan_con",
@@ -1171,7 +933,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00:"
+                ipv6_gw="2a02:ed0:52fe:ec00:",
             )
 
 
@@ -1179,34 +941,23 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
     """
     Testing scenarios for dummy type connections.
     """
+
     data = {
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
             "autoconnect no save no"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
             "autoconnect yes save no"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
             "autoconnect no save yes"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
@@ -1215,11 +966,7 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
@@ -1228,11 +975,7 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
@@ -1241,11 +984,7 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
@@ -1254,11 +993,7 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
         (
             "nmcli connection add "
             "type dummy con-name dummy_con ifname dummy_0 "
@@ -1267,32 +1002,19 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
             "ipv4.gateway 192.168.23.254 "
             "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
             "ipv6.gateway 2a02:ed0:52fe:ec00::"
-        ): (
-            0,
-            "",
-            ""
-        ),
+        ): (0, "", ""),
     }
 
     def test_add_connection_defaults(self, mock):
-        mock.network.nmcli.add_dummy(
-            con_name="dummy_con",
-            ifname="dummy_0"
-        )
+        mock.network.nmcli.add_dummy(con_name="dummy_con", ifname="dummy_0")
 
     def test_add_connection_with_autoconnect(self, mock):
         mock.network.nmcli.add_dummy(
-            con_name="dummy_con",
-            ifname="dummy_0",
-            auto_connect=True
+            con_name="dummy_con", ifname="dummy_0", auto_connect=True
         )
 
     def test_add_connection_with_save(self, mock):
-        mock.network.nmcli.add_dummy(
-            con_name="dummy_con",
-            ifname="dummy_0",
-            save=True
-        )
+        mock.network.nmcli.add_dummy(con_name="dummy_con", ifname="dummy_0", save=True)  # noqa: E501
 
     def test_add_connection_with_static_ips(self, mock):
         mock.network.nmcli.add_dummy(
@@ -1303,13 +1025,13 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
             ipv4_gw="192.168.23.254",
             ipv6_method="manual",
             ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-            ipv6_gw="2a02:ed0:52fe:ec00::"
+            ipv6_gw="2a02:ed0:52fe:ec00::",
         )
 
     def test_add_connection_with_invalid_ipv4_address(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 192.168.23.2.2 is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 192.168.23.2.2 is in-valid",
         ):
             mock.network.nmcli.add_dummy(
                 con_name="dummy_con",
@@ -1319,13 +1041,14 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_address(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid"  # noqa: E501
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00:dc3f:f939:a573 is in-valid"
+            # noqa: E501
         ):
             mock.network.nmcli.add_dummy(
                 con_name="dummy_con",
@@ -1335,13 +1058,13 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv4_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 192.168.23.254.2 is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 192.168.23.254.2 is in-valid",
         ):
             mock.network.nmcli.add_dummy(
                 con_name="dummy_con",
@@ -1351,13 +1074,13 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254.2",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00::"
+                ipv6_gw="2a02:ed0:52fe:ec00::",
             )
 
     def test_add_connection_with_invalid_ipv6_gateway(self, mock):
         with pytest.raises(
-                expected_exception=InvalidIPException,
-                match="IP address 2a02:ed0:52fe:ec00: is in-valid"
+            expected_exception=InvalidIPException,
+            match="IP address 2a02:ed0:52fe:ec00: is in-valid",
         ):
             mock.network.nmcli.add_dummy(
                 con_name="dummy_con",
@@ -1367,5 +1090,5 @@ class TestNmcliDummyConnection(NmcliConnectionTypeIPConfigurable):
                 ipv4_gw="192.168.23.254",
                 ipv6_method="manual",
                 ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
-                ipv6_gw="2a02:ed0:52fe:ec00:"
+                ipv6_gw="2a02:ed0:52fe:ec00:",
             )

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -266,6 +266,16 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         ): (0, "", ""),
         (
             "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 autoconnect "
+            "yes save yes"
+        ): (0, "", ""),
+        (
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 autoconnect "
+            "no save no"
+        ): (0, "", ""),
+        (
+            "nmcli connection add "
             "type ethernet con-name ethernet_con ifname enp8s0f0 save yes"
         ): (0, "", ""),
         (
@@ -370,6 +380,22 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
             name="ethernet_con", ifname="enp8s0f0", save=True
         )
 
+    def test_add_connection_with_autoconnect_and_save(self, mock):
+        mock.network.nmcli.add_ethernet_connection(
+            name="ethernet_con",
+            ifname="enp8s0f0",
+            auto_connect=True,
+            save=True,
+        )
+
+    def test_add_connection_with_no_autoconnect_and_no_save(self, mock):
+        mock.network.nmcli.add_ethernet_connection(
+            name="ethernet_con",
+            ifname="enp8s0f0",
+            auto_connect=False,
+            save=False,
+        )
+
     def test_add_connection_with_static_ips(self, mock):
         mock.network.nmcli.add_ethernet_connection(
             name="ethernet_con",
@@ -386,8 +412,8 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
             match=".*Error: failed to modify ipv4.addresses: "
-                  "invalid IP address: "
-                  "Invalid IPv4 address '192.186.23.2.2'..*",
+            "invalid IP address: "
+            "Invalid IPv4 address '192.186.23.2.2'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -404,9 +430,9 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
             match=".*Error: failed to modify ipv6.addresses: "
-                  "invalid IP address: "
-                  "Invalid IPv6 address "
-                  "'2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",
+            "invalid IP address: "
+            "Invalid IPv6 address "
+            "'2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -423,8 +449,8 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
             match=".*Error: failed to modify ipv4.gateway: "
-                  "invalid IP address: "
-                  "Invalid IPv4 address '192.168.23.254.2'.*",
+            "invalid IP address: "
+            "Invalid IPv4 address '192.168.23.254.2'.*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -441,8 +467,8 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
             match=".*Error: failed to modify ipv6.gateway: "
-                  "invalid IP address: "
-                  "Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",
+            "invalid IP address: "
+            "Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -464,7 +490,7 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
         with pytest.raises(
             expected_exception=CommandExecutionFailure,
             match=".*Error: failed to modify 802-3-ethernet.mac-address: "
-                  "'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",
+            "'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3"

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -1,0 +1,826 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the NMCLI service class.
+"""
+import pytest
+
+from rrmngmnt import Host, RootUser
+from rrmngmnt.errors import CommandExecutionFailure
+from rrmngmnt.nmcli import ConnectionDoesNotExistException, \
+    DeviceDoesNotExistException
+from tests.common import FakeExecutorFactory
+
+MOCK_ROOT_PASSWORD = "11111"
+
+MOCK_IP = "1.1.1.1"
+
+
+@pytest.fixture(scope="class")
+def provision_host(request):
+    """
+    Provisions a mock host.
+    """
+    ip = getattr(request.cls, "host_ip")
+    root_password = getattr(request.cls, "root_password")
+    data = getattr(request.cls, "data")
+
+    mock = Host(ip=ip)
+    mock.add_user(RootUser(password=root_password))
+    mock.executor_factory = FakeExecutorFactory(
+        cmd_to_data=data, files_content=None
+    )
+    return mock
+
+
+@pytest.fixture(scope="function")
+def mock(provision_host):
+    return provision_host
+
+
+class NmcliBase(object):
+    """
+    Base class for tests
+    """
+    host_ip = MOCK_IP
+    root_password = MOCK_ROOT_PASSWORD
+    data = {}
+
+
+class TestNmcliBasic(NmcliBase):
+    """
+    Testing basic scenarios for existing connections.
+    """
+    data = {
+        "nmcli connection show ovirtmgmt": (
+            0,
+            "",
+            ""
+        ),
+        "nmcli connection show ovirtmgmtt": (
+            10,
+            "",
+            "Error: ovirtmgmtt - no such connection profile."
+        ),
+        "nmcli device show ovirtmgmt": (
+            0,
+            "",
+            ""
+        ),
+        "nmcli device show ovirtmgmtt": (
+            10,
+            "",
+            "Error: Device 'ovirtmgmtt' not found."
+        ),
+        "nmcli -g connection.uuid connection show ovirtmgmt": (
+            0,
+            "f142311f-9e79-4b9e-9d8a-f591e0cec44a",
+            ""
+        ),
+        "nmcli -g connection.uuid connection show ovirtmgmtt": (
+            10,
+            "",
+            "Error: ovirtmgmtt - no such connection profile"
+        ),
+        "nmcli -m multiline connection show": (
+            0,
+            "\n".join(
+                [
+                    "NAME:                                   ovirtmgmt",
+                    "UUID:                                   f142311f-9e79-4b9e-9d8a-f591e0cec44a",  # noqa: E501
+                    "TYPE:                                   bridge",
+                    "DEVICE:                                 ovirtmgmt",
+                    "NAME:                                   virbr0",
+                    "UUID:                                   56d36466-2a58-4461-98ba-fbe11700955a",  # noqa: E501
+                    "TYPE:                                   bridge",
+                    "DEVICE:                                 virbr0",
+                    "NAME:                                   enp8s0f0",
+                    "UUID:                                   f58d1962-459d-47de-b090-55091dd3d702",  # noqa: E501
+                    "TYPE:                                   ethernet",
+                    "DEVICE:                                 enp8s0f0"
+                ]
+            ),
+            ""
+        ),
+        "nmcli connection show virbr0": (
+            0,
+            "",
+            ""
+        ),
+        "nmcli connection show enp8s0f0": (
+            0,
+            "",
+            ""
+        ),
+        "nmcli -g connection.uuid connection show virbr0": (
+            0,
+            "56d36466-2a58-4461-98ba-fbe11700955a",
+            ""
+        ),
+        "nmcli -g connection.uuid connection show enp8s0f0": (
+            0,
+            "f58d1962-459d-47de-b090-55091dd3d702",
+            ""
+        ),
+        "nmcli -g GENERAL.TYPE device show enp8s0f0": (
+            0,
+            "ethernet",
+            ""
+        ),
+        "nmcli -g GENERAL.TYPE device show enp8s0f00": (
+            10,
+            "",
+            "Error: Device 'enp8s0f00' not found."
+        ),
+        "nmcli connection up ovirtmgmt": (
+            0,
+            "Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
+            ""
+        ),
+        "nmcli connection down ovirtmgmt": (
+            0,
+            "Connection successfully terminated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
+            ""
+        ),
+        "nmcli connection up ovirtmgmtt": (
+            10,
+            "",
+            "Error: unknown connection 'ovirtmgmtt'."
+        ),
+        "nmcli connection down ovirtmgmtt": (
+            10,
+            "",
+            "Error: unknown connection 'ovirtmgmtt'."
+        ),
+        "nmcli connection delete ovirtmgmt": (
+            0,
+            "Connection successfully removed (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1985)",  # noqa: E501
+            ""
+        ),
+        "nmcli connection delete ovirtmgmtt": (
+            10,
+            "",
+            "Error: unknown connection 'ovirtmgmtt'."
+        ),
+    }
+
+    def test_check_connection_exists(self, mock):
+        assert mock.network.nmcli.is_connection_exist(connection="ovirtmgmt")
+
+    def test_check_connection_exists_when_it_does_not(self, mock):
+        assert not mock.network.nmcli.is_connection_exist(
+            connection="ovirtmgmtt"
+        )
+
+    def test_check_device_exists(self, mock):
+        assert mock.network.nmcli.is_device_exist(device="ovirtmgmt")
+
+    def test_check_device_exists_when_it_does_not(self, mock):
+        assert not mock.network.nmcli.is_device_exist(device="ovirtmgmtt")
+
+    def test_get_connection_uuid(self, mock):
+        assert (
+                mock.network.nmcli.get_connection_uuid(con_name="ovirtmgmt")
+                == "f142311f-9e79-4b9e-9d8a-f591e0cec44a"
+        )
+
+    def test_get_non_existing_connection_uuid(self, mock):
+        with pytest.raises(
+            expected_exception=ConnectionDoesNotExistException,
+            match="connection ovirtmgmtt does not exist"
+        ):
+            mock.network.nmcli.get_connection_uuid(
+                con_name="ovirtmgmtt"
+            )
+
+    def test_get_all_existing_connections_uuids(self, mock):
+        all_cons_uuids = mock.network.nmcli.get_all_connections_uuids()
+        assert all_cons_uuids == [
+            "f142311f-9e79-4b9e-9d8a-f591e0cec44a",
+            "56d36466-2a58-4461-98ba-fbe11700955a",
+            "f58d1962-459d-47de-b090-55091dd3d702"
+        ]
+
+    def test_get_device_type(self, mock):
+        assert (
+                mock.network.nmcli.get_device_type(device="enp8s0f0")
+                == "ethernet"
+        )
+
+    def test_get_non_existing_device_type(self, mock):
+        with pytest.raises(
+            expected_exception=CommandExecutionFailure,
+            match="Error: Device 'enp8s0f00' not found."
+        ):
+            mock.network.nmcli.get_device_type(device="enp8s0f00")
+
+    def test_set_connection_up(self, mock):
+        mock.network.nmcli.set_connection_state(
+            connection="ovirtmgmt", state="up"
+        )
+
+    def test_set_connection_down(self, mock):
+        mock.network.nmcli.set_connection_state(
+            connection="ovirtmgmt", state="down"
+        )
+
+    def test_set_non_existing_connection_up(self, mock):
+        with pytest.raises(
+                expected_exception=ConnectionDoesNotExistException,
+                match="connection ovirtmgmtt does not exist"
+        ):
+            mock.network.nmcli.set_connection_state(
+                connection="ovirtmgmtt", state="up"
+            )
+
+    def test_set_non_existing_connection_down(self, mock):
+        with pytest.raises(
+                expected_exception=ConnectionDoesNotExistException,
+                match="connection ovirtmgmtt does not exist"
+        ):
+            mock.network.nmcli.set_connection_state(
+                connection="ovirtmgmtt", state="down"
+            )
+
+    def test_delete_connection(self, mock):
+        mock.network.nmcli.delete_connection(connection="ovirtmgmt")
+
+    def test_delete_non_existing_connection(self, mock):
+        with pytest.raises(
+                expected_exception=ConnectionDoesNotExistException,
+                match="connection ovirtmgmtt does not exist"
+        ):
+            mock.network.nmcli.delete_connection(connection="ovirtmgmtt")
+
+
+class NmcliConnectionType(NmcliBase):
+    """
+    Base class for testing different connection types.
+    """
+    def test_add_connection_defaults(self, mock):
+        pass
+
+    def test_add_connection_with_autoconnect(self, mock):
+        pass
+
+    def test_add_connection_with_save(self, mock):
+        pass
+
+    def test_add_connection_with_static_ips(self, mock):
+        pass
+
+
+class TestNmcliEthernetConnection(NmcliConnectionType):
+    """
+    Testing scenarios for ethernet type connections.
+    """
+    data = {
+        (
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 "
+            "autoconnect no save no"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 "
+            "autoconnect yes save no"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 "
+            "autoconnect no save yes"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 "
+            "autoconnect no save no "
+            "ipv4.method manual ipv4.addresses 192.168.23.2 "
+            "ipv4.gateway 192.168.23.254 "
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 "
+            "autoconnect no save no "
+            "mac e8:6a:64:7d:d3:b1"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type ethernet con-name ethernet_con ifname enp8s0f0 "
+            "autoconnect no save no "
+            "mtu 1600"
+        ): (
+            0,
+            "",
+            ""
+        ),
+    }
+
+    def test_add_connection_defaults(self, mock):
+        mock.network.nmcli.add_ethernet(
+            con_name="ethernet_con",
+            ifname="enp8s0f0"
+        )
+
+    def test_add_connection_with_autoconnect(self, mock):
+        mock.network.nmcli.add_ethernet(
+            con_name="ethernet_con",
+            ifname="enp8s0f0",
+            auto_connect=True
+        )
+
+    def test_add_connection_with_save(self, mock):
+        mock.network.nmcli.add_ethernet(
+            con_name="ethernet_con",
+            ifname="enp8s0f0",
+            save=True
+        )
+
+    def test_add_connection_with_static_ips(self, mock):
+        mock.network.nmcli.add_ethernet(
+            con_name="ethernet_con",
+            ifname="enp8s0f0",
+            ipv4_method="manual",
+            ipv4_addr="192.168.23.2",
+            ipv4_gw="192.168.23.254",
+            ipv6_method="manual",
+            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64",
+            ipv6_gw="2a02:ed0:52fe:ec00::/56"
+        )
+
+    def test_add_ethernet_with_mac(self, mock):
+        mock.network.nmcli.add_ethernet(
+            con_name="ethernet_con",
+            ifname="enp8s0f0",
+            mac="e8:6a:64:7d:d3:b1"
+        )
+
+    def test_add_ethernet_with_mtu(self, mock):
+        mock.network.nmcli.add_ethernet(
+            con_name="ethernet_con",
+            ifname="enp8s0f0",
+            mtu=1600
+        )
+
+
+class TestNmcliBondConnection(NmcliConnectionType):
+    """
+    Testing scenarios for bond type connections.
+    """
+    data = {
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode active-backup miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect yes save no mode active-backup miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save yes mode active-backup miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode active-backup miimon 100 "
+            "ipv4.method manual ipv4.addresses 192.168.23.2 "
+            "ipv4.gateway 192.168.23.254 "
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode balance-rr miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode active-backup miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode balance-xor miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode broadcast miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode 802.3ad miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode balance-tlb miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode balance-alb miimon 100"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type bond con-name bond_con ifname bond0 "
+            "autoconnect no save no mode active-backup miimon 50"
+        ): (
+            0,
+            "",
+            ""
+        ),
+    }
+
+    def test_add_connection_defaults(self, mock):
+        mock.network.nmcli.add_bond(
+            con_name="bond_con",
+            ifname="bond0"
+        )
+
+    def test_add_connection_with_autoconnect(self, mock):
+        mock.network.nmcli.add_bond(
+            con_name="bond_con",
+            ifname="bond0",
+            auto_connect=True
+        )
+
+    def test_add_connection_with_save(self, mock):
+        mock.network.nmcli.add_bond(
+            con_name="bond_con",
+            ifname="bond0",
+            save=True
+        )
+
+    def test_add_connection_with_static_ips(self, mock):
+        mock.network.nmcli.add_bond(
+            con_name="bond_con",
+            ifname="bond0",
+            ipv4_method="manual",
+            ipv4_addr="192.168.23.2",
+            ipv4_gw="192.168.23.254",
+            ipv6_method="manual",
+            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64",
+            ipv6_gw="2a02:ed0:52fe:ec00::/56"
+        )
+
+    @pytest.mark.parametrize(
+        "bond_mode",
+        [
+            "balance-rr",
+            "active-backup",
+            "balance-xor",
+            "broadcast",
+            "802.3ad",
+            "balance-tlb",
+            "balance-alb"
+        ]
+    )
+    def test_add_bond_with_mode(self, mock, bond_mode):
+        mock.network.nmcli.add_bond(
+            con_name="bond_con",
+            ifname="bond0",
+            mode=bond_mode
+        )
+
+    def test_add_bond_with_miimon(self, mock):
+        mock.network.nmcli.add_bond(
+            con_name="bond_con",
+            ifname="bond0",
+            miimon=50
+        )
+
+
+class TestNmcliSlaveConnection(NmcliConnectionType):
+    """
+    Testing scenarios for bond type connections.
+    """
+    data = {
+        (
+            "nmcli connection add "
+            "type ethernet con-name bond0_slave ifname enp8s0f0 "
+            "autoconnect no save no master bond0"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type ethernet con-name bond0_slave ifname enp8s0f0 "
+            "autoconnect yes save no master bond0"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type ethernet con-name bond0_slave ifname enp8s0f0 "
+            "autoconnect no save yes master bond0"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        "nmcli -g GENERAL.TYPE device show enp8s0f0": (
+            0,
+            "ethernet",
+            ""
+        ),
+    }
+
+    def test_add_connection_defaults(self, mock):
+        mock.network.nmcli.add_slave(
+            con_name="bond0_slave",
+            ifname="enp8s0f0",
+            master="bond0"
+        )
+
+    def test_add_connection_with_autoconnect(self, mock):
+        mock.network.nmcli.add_slave(
+            con_name="bond0_slave",
+            ifname="enp8s0f0",
+            master="bond0",
+            auto_connect=True
+        )
+
+    def test_add_connection_with_save(self, mock):
+        mock.network.nmcli.add_slave(
+            con_name="bond0_slave",
+            ifname="enp8s0f0",
+            master="bond0",
+            save=True
+        )
+
+
+class TestNmcliVlanConnection(NmcliConnectionType):
+    """
+    Testing scenarios for VLAN type connections.
+    """
+    data = {
+        (
+            "nmcli connection add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "autoconnect no save no "
+            "dev enp8s0f0 id 163"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "autoconnect yes save no "
+            "dev enp8s0f0 id 163"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "autoconnect no save yes "
+            "dev enp8s0f0 id 163"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "autoconnect no save no "
+            "dev enp8s0f0 id 163 "
+            "ipv4.method manual ipv4.addresses 192.168.23.2 "
+            "ipv4.gateway 192.168.23.254 "
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "autoconnect no save no "
+            "dev enp8s0f0 id 163 "
+            "mtu 1600"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        "nmcli device show enp8s0f0": (
+            0,
+            "ethernet",
+            ""
+        ),
+        "nmcli device show enp8s0f00": (
+            10,
+            "",
+            "Error: Device 'enp8s0f00' not found."
+        ),
+    }
+
+    def test_add_connection_defaults(self, mock):
+        mock.network.nmcli.add_vlan(
+            con_name="vlan_con",
+            dev="enp8s0f0",
+            vlan_id=163
+        )
+
+    def test_add_connection_with_autoconnect(self, mock):
+        mock.network.nmcli.add_vlan(
+            con_name="vlan_con",
+            dev="enp8s0f0",
+            vlan_id=163,
+            auto_connect=True
+        )
+
+    def test_add_connection_with_save(self, mock):
+        mock.network.nmcli.add_vlan(
+            con_name="vlan_con",
+            dev="enp8s0f0",
+            vlan_id=163,
+            save=True
+        )
+
+    def test_add_connection_with_static_ips(self, mock):
+        mock.network.nmcli.add_vlan(
+            con_name="vlan_con",
+            dev="enp8s0f0",
+            vlan_id=163
+        )
+
+    def test_add_vlan_with_invalid_dev(self, mock):
+        with pytest.raises(
+            expected_exception=DeviceDoesNotExistException,
+            match="device enp8s0f00 does not exist"
+        ):
+            mock.network.nmcli.add_vlan(
+                con_name="vlan_con",
+                dev="enp8s0f00",
+                vlan_id=163
+            )
+
+    def test_add_vlan_with_mtu(self, mock):
+        mock.network.nmcli.add_vlan(
+            con_name="vlan_con",
+            dev="enp8s0f0",
+            vlan_id=163,
+            mtu=1600
+        )
+
+
+class TestNmcliDummyConnection(NmcliConnectionType):
+    """
+    Testing scenarios for dummy type connections.
+    """
+    data = {
+        (
+            "nmcli connection add "
+            "type dummy con-name dummy_con ifname dummy_0 "
+            "autoconnect no save no"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type dummy con-name dummy_con ifname dummy_0 "
+            "autoconnect yes save no"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type dummy con-name dummy_con ifname dummy_0 "
+            "autoconnect no save yes"
+        ): (
+            0,
+            "",
+            ""
+        ),
+        (
+            "nmcli connection add "
+            "type dummy con-name dummy_con ifname dummy_0 "
+            "autoconnect no save no "
+            "ipv4.method manual ipv4.addresses 192.168.23.2 "
+            "ipv4.gateway 192.168.23.254 "
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+        ): (
+            0,
+            "",
+            ""
+        ),
+    }
+
+    def test_add_connection_defaults(self, mock):
+        mock.network.nmcli.add_dummy(
+            con_name="dummy_con",
+            ifname="dummy_0"
+        )
+
+    def test_add_connection_with_autoconnect(self, mock):
+        mock.network.nmcli.add_dummy(
+            con_name="dummy_con",
+            ifname="dummy_0",
+            auto_connect=True
+        )
+
+    def test_add_connection_with_save(self, mock):
+        mock.network.nmcli.add_dummy(
+            con_name="dummy_con",
+            ifname="dummy_0",
+            save=True
+        )
+
+    def test_add_connection_with_static_ips(self, mock):
+        mock.network.nmcli.add_dummy(
+            con_name="dummy_con",
+            ifname="dummy_0",
+            ipv4_method="manual",
+            ipv4_addr="192.168.23.2",
+            ipv4_gw="192.168.23.254",
+            ipv6_method="manual",
+            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64",
+            ipv6_gw="2a02:ed0:52fe:ec00::/56"
+        )

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -727,8 +727,17 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (0, "", ""),
         (
             "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 dev enp8s0f0 id 163"
+        ): (0, "", ""),
+        (
+            "nmcli con add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "autoconnect yes id 163 dev enp8s0f0"
+        ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "autoconnect yes dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
             "nmcli con add "
@@ -738,7 +747,21 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         (
             "nmcli con add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
+            "save yes dev enp8s0f0 id 163"
+        ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254 "
+            "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
+        ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
@@ -756,7 +779,25 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         (
             "nmcli con add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
+            "dev enp8s0f0 id 163 "
+            "ipv4.method manual ipv6.method manual "
+            "ipv4.addresses 192.168.23.2.2 ipv4.gateway 192.168.23.254 "
+            "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
+        ): (10, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
+            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.gateway 192.168.23.254.2 "
+            "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
+        ): (10, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
             "ipv4.gateway 192.168.23.254.2 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
@@ -774,7 +815,25 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         (
             "nmcli con add "
             "type vlan con-name vlan_con ifname enp8s0f0 "
+            "dev enp8s0f0 id 163 "
+            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.gateway 192.168.23.254 "
+            "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573 "
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
+        ): (10, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 "
+            "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
+            "ipv4.gateway 192.168.23.254 "
+            "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
+            "ipv6.gateway 2a02:ed0:52fe:ec00:"
+        ): (10, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual ipv4.addresses 192.168.23.2 "  # noqa: E501
             "ipv4.gateway 192.168.23.254 "
             "ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "
@@ -785,6 +844,21 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "type vlan con-name vlan_con ifname enp8s0f0 "
             "id 163 dev enp8s0f0 mtu 1600"
         ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "dev enp8s0f0 id 163 mtu 1600"
+        ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "dev enp8s0f0 mtu 1600 id 163"
+        ): (0, "", ""),
+        (
+            "nmcli con add "
+            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "mtu 1600 dev enp8s0f0 id 163"
+        ): (0, "", ""),
         "nmcli device show enp8s0f0": (0, "ethernet", ""),
         "nmcli device show enp8s0f00": (
             10,
@@ -793,6 +867,8 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ),
         "nmcli con add type vlan con-name vlan_con ifname enp8s0f00 "
         "id 163 dev enp8s0f00": (10, "", ""),
+        "nmcli con add type vlan con-name vlan_con ifname enp8s0f00 "
+        "dev enp8s0f00 id 163": (10, "", ""),
     }
 
     def test_add_connection_defaults(self, mock):

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -52,19 +52,50 @@ class TestNmcliSanity(NmcliBase):
     """
 
     data = {
+        "nmcli -g GENERAL.DEVICE device show": (
+            0,
+            "\n".join(["virbr0", "enp1s0f1", "enp2s0f0", "enp2s0f1"]),
+            "",
+        ),
         "nmcli -t connection show": (
             0,
             "\n".join(
                 [
-                    "virbr0:ba7aafc8-438e-4f8d-9f6e-3991fecebac0:bridge:virbr0",
-                    "enp1s0f1:702b48ac-750f-4856-8124-c8c55d8e3dda:802-3-ethernet:",
-                    "enp2s0f0:d2ee2c05-b28f-4529-8f42-ea4dbb17f308:802-3-ethernet:",
-                    "enp2s0f1:98e5c49f-bd72-45b4-b377-bfb74b6665ca:802-3-ethernet:",
-                    "enp2s0f2:a7199332-f99d-4152-babd-79d37d53478c:802-3-ethernet:",
-                    "enp2s0f3:86dbb462-6404-4444-8f4b-b78d045f4c9d:802-3-ethernet:"
+                    "virbr0:ba7aafc8-438e-4f8d-9f6e-3991fecebac0:bridge"
+                    ":virbr0",
+                    "enp1s0f1:702b48ac-750f-4856-8124-c8c55d8e3dda:"
+                    "802-3-ethernet:",
+                    "enp2s0f0:d2ee2c05-b28f-4529-8f42-ea4dbb17f308:"
+                    "802-3-ethernet:",
+                    "enp2s0f1:98e5c49f-bd72-45b4-b377-bfb74b6665ca:"
+                    "802-3-ethernet:",
+                    "enp2s0f2:a7199332-f99d-4152-babd-79d37d53478c:"
+                    "802-3-ethernet:",
+                    "enp2s0f3:86dbb462-6404-4444-8f4b-b78d045f4c9d:"
+                    "802-3-ethernet:",
                 ]
             ),
-            ""
+            "",
+        ),
+        "nmcli -e no -g GENERAL.TYPE,GENERAL.HWADDR,GENERAL.MTU device show "
+        "virbr0": (0, "\n".join(["bridge", "52:54:00:9C:D2:15", "1500"]), ""),
+        "nmcli -e no -g GENERAL.TYPE,GENERAL.HWADDR,GENERAL.MTU device show "
+        "enp1s0f1": (
+            0,
+            "\n".join(["ethernet", "00:25:90:C6:D9:B1", "1500"]),
+            "",
+        ),
+        "nmcli -e no -g GENERAL.TYPE,GENERAL.HWADDR,GENERAL.MTU device show "
+        "enp2s0f0": (
+            0,
+            "\n".join(["ethernet", "00:E0:ED:33:3F:7E", "1500"]),
+            "",
+        ),
+        "nmcli -e no -g GENERAL.TYPE,GENERAL.HWADDR,GENERAL.MTU device show "
+        "enp2s0f1": (
+            0,
+            "\n".join(["ethernet", "00:E0:ED:33:3F:7F", "1500"]),
+            "",
         ),
         "nmcli connection show ovirtmgmt": (0, "", ""),
         "nmcli connection show ovirtmgmtt": (
@@ -93,18 +124,15 @@ class TestNmcliSanity(NmcliBase):
             "\n".join(
                 [
                     "NAME:                                   ovirtmgmt",
-                    "UUID:                                   f142311f-9e79-4b9e-9d8a-f591e0cec44a",
-                    # noqa: E501
+                    "UUID:                                   f142311f-9e79-4b9e-9d8a-f591e0cec44a",  # noqa: E501
                     "TYPE:                                   bridge",
                     "DEVICE:                                 ovirtmgmt",
                     "NAME:                                   virbr0",
-                    "UUID:                                   56d36466-2a58-4461-98ba-fbe11700955a",
-                    # noqa: E501
+                    "UUID:                                   56d36466-2a58-4461-98ba-fbe11700955a",  # noqa: E501
                     "TYPE:                                   bridge",
                     "DEVICE:                                 virbr0",
                     "NAME:                                   enp8s0f0",
-                    "UUID:                                   f58d1962-459d-47de-b090-55091dd3d702",
-                    # noqa: E501
+                    "UUID:                                   f58d1962-459d-47de-b090-55091dd3d702",  # noqa: E501
                     "TYPE:                                   ethernet",
                     "DEVICE:                                 enp8s0f0",
                 ]
@@ -173,35 +201,73 @@ class TestNmcliSanity(NmcliBase):
 
     def test_get_all_connections(self, mock):
         connections = mock.network.nmcli.get_all_connections()
-        assert (
-                connections
-                == [
-                    {'device': 'virbr0',
-                     'name': 'virbr0',
-                     'type': 'bridge',
-                     'uuid': 'ba7aafc8-438e-4f8d-9f6e-3991fecebac0'},
-                    {'device': '',
-                     'name': 'enp1s0f1',
-                     'type': '802-3-ethernet',
-                     'uuid': '702b48ac-750f-4856-8124-c8c55d8e3dda'},
-                    {'device': '',
-                     'name': 'enp2s0f0',
-                     'type': '802-3-ethernet',
-                     'uuid': 'd2ee2c05-b28f-4529-8f42-ea4dbb17f308'},
-                    {'device': '',
-                     'name': 'enp2s0f1',
-                     'type': '802-3-ethernet',
-                     'uuid': '98e5c49f-bd72-45b4-b377-bfb74b6665ca'},
-                    {'device': '',
-                     'name': 'enp2s0f2',
-                     'type': '802-3-ethernet',
-                     'uuid': 'a7199332-f99d-4152-babd-79d37d53478c'},
-                    {'device': '',
-                     'name': 'enp2s0f3',
-                     'type': '802-3-ethernet',
-                     'uuid': '86dbb462-6404-4444-8f4b-b78d045f4c9d'}
-                ]
-        )
+        assert connections == [
+            {
+                "device": "virbr0",
+                "name": "virbr0",
+                "type": "bridge",
+                "uuid": "ba7aafc8-438e-4f8d-9f6e-3991fecebac0",
+            },
+            {
+                "device": "",
+                "name": "enp1s0f1",
+                "type": "802-3-ethernet",
+                "uuid": "702b48ac-750f-4856-8124-c8c55d8e3dda",
+            },
+            {
+                "device": "",
+                "name": "enp2s0f0",
+                "type": "802-3-ethernet",
+                "uuid": "d2ee2c05-b28f-4529-8f42-ea4dbb17f308",
+            },
+            {
+                "device": "",
+                "name": "enp2s0f1",
+                "type": "802-3-ethernet",
+                "uuid": "98e5c49f-bd72-45b4-b377-bfb74b6665ca",
+            },
+            {
+                "device": "",
+                "name": "enp2s0f2",
+                "type": "802-3-ethernet",
+                "uuid": "a7199332-f99d-4152-babd-79d37d53478c",
+            },
+            {
+                "device": "",
+                "name": "enp2s0f3",
+                "type": "802-3-ethernet",
+                "uuid": "86dbb462-6404-4444-8f4b-b78d045f4c9d",
+            },
+        ]
+
+    def test_get_all_devices(self, mock):
+        devices = mock.network.nmcli.get_all_devices()
+        assert devices == [
+            {
+                "name": "virbr0",
+                "type": "bridge",
+                "mac": "52:54:00:9C:D2:15",
+                "mtu": "1500",
+            },
+            {
+                "name": "enp1s0f1",
+                "type": "ethernet",
+                "mac": "00:25:90:C6:D9:B1",
+                "mtu": "1500",
+            },
+            {
+                "name": "enp2s0f0",
+                "type": "ethernet",
+                "mac": "00:E0:ED:33:3F:7E",
+                "mtu": "1500",
+            },
+            {
+                "name": "enp2s0f1",
+                "type": "ethernet",
+                "mac": "00:E0:ED:33:3F:7F",
+                "mtu": "1500",
+            },
+        ]
 
     def test_set_connection_up(self, mock):
         mock.network.nmcli.set_connection_state(
@@ -215,8 +281,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_set_non_existing_connection_up(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: unknown connection 'ovirtmgmtt'..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.set_connection_state(
                 connection="ovirtmgmtt", state="up"
@@ -224,8 +290,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_set_non_existing_connection_down(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: unknown connection 'ovirtmgmtt'..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.set_connection_state(
                 connection="ovirtmgmtt", state="down"
@@ -244,8 +310,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_modify_non_existing_connection(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: unknown connection 'ovirtmgmtt'..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.modify_connection(
                 connection="ovirtmgmtt", properties={"autoconnect": "yes"}
@@ -256,8 +322,8 @@ class TestNmcliSanity(NmcliBase):
 
     def test_delete_non_existing_connection(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: unknown connection 'ovirtmgmtt'..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: unknown connection 'ovirtmgmtt'..*",
         ):
             mock.network.nmcli.delete_connection(connection="ovirtmgmtt")
 
@@ -459,10 +525,10 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv4_address(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: failed to modify ipv4.addresses: "
-                      "invalid IP address: "
-                      "Invalid IPv4 address '192.186.23.2.2'..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: failed to modify ipv4.addresses: "
+            "invalid IP address: "
+            "Invalid IPv4 address '192.186.23.2.2'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -477,11 +543,11 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv6_address(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: failed to modify ipv6.addresses: "
-                      "invalid IP address: "
-                      "Invalid IPv6 address "
-                      "'2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: failed to modify ipv6.addresses: "
+            "invalid IP address: "
+            "Invalid IPv6 address "
+            "'2a02:ed0:52fe:ec00:dc3f:f939:a573'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -496,10 +562,10 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv4_gateway(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: failed to modify ipv4.gateway: "
-                      "invalid IP address: "
-                      "Invalid IPv4 address '192.168.23.254.2'.*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: failed to modify ipv4.gateway: "
+            "invalid IP address: "
+            "Invalid IPv4 address '192.168.23.254.2'.*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -514,10 +580,10 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_connection_with_invalid_ipv6_gateway(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: failed to modify ipv6.gateway: "
-                      "invalid IP address: "
-                      "Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: failed to modify ipv6.gateway: "
+            "invalid IP address: "
+            "Invalid IPv6 address '2a02:ed0:52fe:ec00:'..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con",
@@ -537,9 +603,9 @@ class TestNmcliEthernetConnection(NmcliConnectionTypeIPConfigurable):
 
     def test_add_ethernet_with_invalid_mac(self, mock):
         with pytest.raises(
-                expected_exception=CommandExecutionFailure,
-                match=".*Error: failed to modify 802-3-ethernet.mac-address: "
-                      "'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",
+            expected_exception=CommandExecutionFailure,
+            match=".*Error: failed to modify 802-3-ethernet.mac-address: "
+            "'e8:6a:64:7d:d3' is not a valid Ethernet MAC..*",
         ):
             mock.network.nmcli.add_ethernet_connection(
                 name="ethernet_con", ifname="enp8s0f0", mac="e8:6a:64:7d:d3"

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -309,8 +309,8 @@ class TestNmcliEthernetConnection(NmcliConnectionType):
             "autoconnect no save no "
             "ipv4.method manual ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
-            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
-            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (
             0,
             "",
@@ -366,8 +366,8 @@ class TestNmcliEthernetConnection(NmcliConnectionType):
             ipv4_addr="192.168.23.2",
             ipv4_gw="192.168.23.254",
             ipv6_method="manual",
-            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64",
-            ipv6_gw="2a02:ed0:52fe:ec00::/56"
+            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
+            ipv6_gw="2a02:ed0:52fe:ec00::"
         )
 
     def test_add_ethernet_with_mac(self, mock):
@@ -423,8 +423,8 @@ class TestNmcliBondConnection(NmcliConnectionType):
             "autoconnect no save no mode active-backup miimon 100 "
             "ipv4.method manual ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
-            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
-            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (
             0,
             "",
@@ -532,8 +532,8 @@ class TestNmcliBondConnection(NmcliConnectionType):
             ipv4_addr="192.168.23.2",
             ipv4_gw="192.168.23.254",
             ipv6_method="manual",
-            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64",
-            ipv6_gw="2a02:ed0:52fe:ec00::/56"
+            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
+            ipv6_gw="2a02:ed0:52fe:ec00::"
         )
 
     @pytest.mark.parametrize(
@@ -668,8 +668,8 @@ class TestNmcliVlanConnection(NmcliConnectionType):
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
-            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
-            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (
             0,
             "",
@@ -786,8 +786,8 @@ class TestNmcliDummyConnection(NmcliConnectionType):
             "autoconnect no save no "
             "ipv4.method manual ipv4.addresses 192.168.23.2 "
             "ipv4.gateway 192.168.23.254 "
-            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64 "  # noqa: E501
-            "ipv6.gateway 2a02:ed0:52fe:ec00::/56"
+            "ipv6.method manual ipv6.addresses 2a02:ed0:52fe:ec00:dc3f:f939:a573:5984 "  # noqa: E501
+            "ipv6.gateway 2a02:ed0:52fe:ec00::"
         ): (
             0,
             "",
@@ -823,6 +823,6 @@ class TestNmcliDummyConnection(NmcliConnectionType):
             ipv4_addr="192.168.23.2",
             ipv4_gw="192.168.23.254",
             ipv6_method="manual",
-            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984/64",
-            ipv6_gw="2a02:ed0:52fe:ec00::/56"
+            ipv6_addr="2a02:ed0:52fe:ec00:dc3f:f939:a573:5984",
+            ipv6_gw="2a02:ed0:52fe:ec00::"
         )

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -164,6 +164,21 @@ class TestNmcliSanity(NmcliBase):
             "",
             "Error: unknown connection 'ovirtmgmtt'."
         ),
+        "nmcli connection modify ovirtmgmt autoconnect yes": (
+            0,
+            "",
+            ""
+        ),
+        "nmcli connection modify ovirtmgmt autoconnectt yes": (
+            10,
+            "",
+            ""
+        ),
+        "nmcli connection modify ovirtmgmtt autoconnect yes": (
+            10,
+            "",
+            "Error: unknown connection 'ovirtmgmtt'."
+        ),
     }
 
     def test_check_connection_exists(self, mock):
@@ -242,6 +257,31 @@ class TestNmcliSanity(NmcliBase):
         ):
             mock.network.nmcli.set_connection_state(
                 connection="ovirtmgmtt", state="down"
+            )
+
+    def test_modify_connection_autoconnect(self, mock):
+        mock.network.nmcli.modify_connection(
+            connection="ovirtmgmt",
+            properties={"autoconnect": "yes"}
+        )
+
+    def test_modify_connection_with_illegal_property(self, mock):
+        with pytest.raises(
+            expected_exception=CommandExecutionFailure
+        ):
+            mock.network.nmcli.modify_connection(
+                connection="ovirtmgmt",
+                properties={"autoconnectt": "yes"}
+            )
+
+    def test_modify_non_existing_connection(self, mock):
+        with pytest.raises(
+            expected_exception=ConnectionDoesNotExistException,
+            match="connection ovirtmgmtt does not exist"
+        ):
+            mock.network.nmcli.modify_connection(
+                connection="ovirtmgmtt",
+                properties={"autoconnect": "yes"}
             )
 
     def test_delete_connection(self, mock):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
-envlist = py27,py34,py35,py36,pep8
+envlist = py27,py35,py36,pep8
 [tox:travis]
 2.7 = py27, pep8
-3.4 = py34, pep8
 3.5 = py35, pep8
 3.6 = py36, pep8
 [testenv]


### PR DESCRIPTION
This PR introduces a new interface to the nmcli command provided by NetworkManager.

NetworkManager is a standard for networking in Linux, so I believe it is important to have an interface to work with on the remote host.
