### PR TITLE
Fixed an incorrect parameter passed to VLAN creation

### DIFF
--- a/rrmngmnt/nmcli.py
+++ b/rrmngmnt/nmcli.py
@@ -451,7 +451,6 @@ class NMCLI(Service):
                 operation=Operations.ADD,
                 con_type=Types.VLAN,
                 name=con_name,
-                ifname=dev,
                 auto_connect=auto_connect,
                 save=save,
                 ipv4_method=ipv4_method,
@@ -634,7 +633,7 @@ class NMCLI(Service):
 
     @staticmethod
     def _common_options_builder(
-        con_type, con_name, ifname, auto_connect=None, save=None
+        con_type, con_name, ifname=None, auto_connect=None, save=None
     ):
         """
         Generates a string containing common options for the nmcli command.
@@ -658,8 +657,11 @@ class NMCLI(Service):
             return "yes" if value is True else "no"
 
         common_options = (
-            "type {type} con-name {con_name} ifname {ifname}"
-        ).format(type=con_type, con_name=con_name, ifname=ifname)
+            "type {type} con-name {con_name}"
+        ).format(type=con_type, con_name=con_name)
+
+        if ifname:
+            common_options += " ifname {ifname}".format(ifname=ifname)
         if auto_connect is not None:
             common_options += " autoconnect {value}".format(
                 value=_get_str_value(value=auto_connect)

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -889,35 +889,35 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
     data = {
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 id 163 dev enp8s0f0"
+            "type vlan con-name vlan_con id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 dev enp8s0f0 id 163"
+            "type vlan con-name vlan_con dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "autoconnect yes id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "autoconnect yes dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "save yes id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "save yes dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "id 163 dev enp8s0f0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254 "
@@ -926,7 +926,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 ipv4.gateway 192.168.23.254 "
@@ -935,7 +935,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "id 163 dev enp8s0f0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2.2 ipv4.gateway 192.168.23.254 "
@@ -944,7 +944,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2.2 ipv4.gateway 192.168.23.254 "
@@ -953,7 +953,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "id 163 dev enp8s0f0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 "
@@ -963,7 +963,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 "
@@ -973,7 +973,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "id 163 dev enp8s0f0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 "
@@ -983,7 +983,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 "
@@ -993,7 +993,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "id 163 dev enp8s0f0 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 "
@@ -1003,7 +1003,7 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "dev enp8s0f0 id 163 "
             "ipv4.method manual ipv6.method manual "
             "ipv4.addresses 192.168.23.2 "
@@ -1013,32 +1013,32 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
         ): (10, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "id 163 dev enp8s0f0 mtu 1600"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "mtu 1600 id 163 dev enp8s0f0"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "dev enp8s0f0 id 163 mtu 1600"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "dev enp8s0f0 mtu 1600 id 163"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "mtu 1600 dev enp8s0f0 id 163"
         ): (0, "", ""),
         (
             "nmcli connection add "
-            "type vlan con-name vlan_con ifname enp8s0f0 "
+            "type vlan con-name vlan_con "
             "id 163 mtu 1600 dev enp8s0f0"
         ): (0, "", ""),
         "nmcli device show enp8s0f0": (0, "ethernet", ""),
@@ -1047,9 +1047,9 @@ class TestNmcliVlanConnection(NmcliConnectionTypeIPConfigurable):
             "",
             "Error: Device 'enp8s0f00' not found.",
         ),
-        "nmcli connection add type vlan con-name vlan_con ifname enp8s0f00 "
+        "nmcli connection add type vlan con-name vlan_con "
         "id 163 dev enp8s0f00": (10, "", ""),
-        "nmcli connection add type vlan con-name vlan_con ifname enp8s0f00 "
+        "nmcli connection add type vlan con-name vlan_con "
         "dev enp8s0f00 id 163": (10, "", ""),
     }
 


### PR DESCRIPTION
For VLAN connections the parameter 'ifname' must not be
passed. only the 'dev' parameter should be passed to indicate
the VLAN's parent device.