### PR TITLE
Added support for the 'bridge' command.

### DIFF
--- a/rrmngmnt/network.py
+++ b/rrmngmnt/network.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import netaddr
 import os
@@ -478,6 +479,30 @@ class Network(Service):
         self._cmd(cmd_br_down)
         self._cmd(cmd_del_br)
         return True
+
+    @keep_session
+    def get_bridges(self):
+        """
+        Gets a host's bridges details using the 'bridge' command.
+
+        Returns:
+            list[dict]: a list of dicts where each dict represents a bridge,
+                and has the keys:
+                    * "ifname" -> str
+                        The interface enslaved to the bridge.
+                    * "flags" -> list[str]
+                        A list of flags associated with the bridge.
+                    * "mtu" -> int
+                        The MTU configured on the bridge.
+                    * "master" -> str
+                        The bridge name.
+                    * "state" -> str
+                    * "priority" -> int
+                    * "cost" -> int
+                    * "ifindex" -> int
+        """
+        raw_bridges = self._cmd(shlex.split("bridge -j link show"))
+        return json.loads(s=raw_bridges)
 
     @keep_session
     def get_info(self):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -24,6 +24,18 @@ class TestNetwork(object):
     __test__ = True
 
     data = {
+        "bridge -j link show": (
+            0,
+            '[{"ifindex":2,"ifname":"enp1s0f0","flags":'
+            '["BROADCAST","MULTICAST","UP","LOWER_UP"],'
+            '"mtu":1500,"master":"ovirtmgmt","state":"forwarding",'
+            '"priority":32,"cost":100},'
+            '{"ifindex":9,"ifname":"virbr0-nic","flags":'
+            '["BROADCAST","MULTICAST"],'
+            '"mtu":1500,"master":"virbr0","state":"disabled",'
+            '"priority":32,"cost":100}]',
+            ""
+        ),
         'ip route': (
             0,
             '\n'.join(
@@ -277,6 +289,33 @@ class TestNetwork(object):
     def test_add_ip_with_subnet_mask(self):
         assert get_host().network.add_ip(
             nic="eth0", ip="1.2.3.4", mask="255.255.255.0"
+        )
+
+    def test_get_bridges(self):
+        assert (
+            get_host().network.get_bridges() ==
+            [
+                {
+                    "ifindex": 2,
+                    "ifname": "enp1s0f0",
+                    "flags": ["BROADCAST", "MULTICAST", "UP", "LOWER_UP"],
+                    "mtu": 1500,
+                    "master": "ovirtmgmt",
+                    "state": "forwarding",
+                    "priority": 32,
+                    "cost": 100
+                },
+                {
+                    "ifindex": 9,
+                    "ifname": "virbr0-nic",
+                    "flags": ["BROADCAST", "MULTICAST"],
+                    "mtu": 1500,
+                    "master": "virbr0",
+                    "state": "disabled",
+                    "priority": 32,
+                    "cost": 100
+                }
+            ]
         )
 
 


### PR DESCRIPTION
Added a function in the network module for retrieving
bridges data using the 'bridge' command.

This is necessary since the 'brctl' command which is used
in the current bridge related methods is no longer supported
by RHEL 8.x.