### PR TITLE
Remove Python2.7 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 services:
   - docker
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,7 @@ classifier =
     License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Operating System :: POSIX
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
 keywords =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-envlist = py27,py35,py36,pep8
+envlist = py35,py36,pep8
 [tox:travis]
-2.7 = py27, pep8
 3.5 = py35, pep8
 3.6 = py36, pep8
 [testenv]


### PR DESCRIPTION
At Jan 01 2020 Python 2.7 has reached its EOL.
As time passes more and more packages drop support
for py2.7 making it more difficult to enhance the library
we new abilites.

This patch removes the testing of py2.7 and releases
the maintainers from the struggles of failing CI.