### PR TITLE
Change Python supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 services:
   - docker
 python:
-- '3.5'
 - '3.6'
+- '3.7'
 install:
 - pip install tox tox-travis codecov
 script:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,8 @@ classifier =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 keywords =
     remote
     resource

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py35,py36,pep8
+envlist = py36,py37,pep8
 [tox:travis]
-3.5 = py35, pep8
 3.6 = py36, pep8
+3.7 = py37, pep8
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt


### PR DESCRIPTION
As Python 3.5 reached its EOL according to [1] it was dropped.
This commit also adds support for Python3.7

[1] - https://www.python.org/dev/peps/pep-0478/#id4