### PR TITLE
Add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 # PyBuilder
 target/
 python-rrmngmnt.iml
+/.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,6 @@ docs/_build/
 # PyBuilder
 target/
 python-rrmngmnt.iml
+
+# Pycharm
 /.venv/


### PR DESCRIPTION
.venv is common to virtual-environments created in PyCharm IDE.
This commit adds it to be ignored by git.