### PR TITLE
Update pytest skip

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest>=2.8.7
+pytest>=7.0.0
 pytest-cov
 pytest-docker
 docker-compose

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -20,7 +20,7 @@ def provisioned_hosts(docker_ip, docker_services):
     return hosts
 
 
-@pytest.mark.skip(msg="Not enough tests in module to justify running")
+@pytest.mark.skip(reason="Not enough tests in module to justify running")
 def test_echo(provisioned_hosts):
     ubuntu_host = provisioned_hosts['ubuntu']
     ubuntu_host.executor().run_cmd(['echo', 'hello'])


### PR DESCRIPTION
msg was deprecated in pytest 7.0.0
https://github.com/pytest-dev/pytest/releases/tag/7.0.0